### PR TITLE
Proposal for choosing dtype and precision of output

### DIFF
--- a/emlearn/cgen.py
+++ b/emlearn/cgen.py
@@ -1,6 +1,8 @@
 
 """Utilities to generate C code"""
 
+FLOATING_DTYPE = 'float'
+FLOATING_PRECISION = 6
 
 def struct_init(*args):
     """Struct initializer
@@ -21,7 +23,10 @@ def constant(val, dtype='float'):
     "3.14f"
     """
     if dtype == 'float':
-        return "{:f}f".format(val)
+        precision_formater = "{{:.{}f}}".format(FLOATING_PRECISION)
+        formatted_value = precision_formater.format(val)
+        formatted_value += 'f' if FLOATING_DTYPE=='float' else ''
+        return formatted_value
     else:
         return str(val)
 
@@ -43,10 +48,9 @@ def array_declare(name, size, dtype='float', modifiers='static const',
     >>> cgen.array_declare("initialized", 3, dtype='int', modifiers='const')
     "const float initialized[3] = { 1, 2, 3 };"
     """
-    
     init = ''
     if values is not None:
         init_values = ', '.join(constant(v, dtype) for v in values)
         init = ' = {{ {init_values} }}'.format(**locals())
-
+    if dtype=='float': dtype=FLOATING_DTYPE
     return '{indent}{modifiers} {dtype} {name}[{size}]{init};{end}'.format(**locals())

--- a/emlearn/convert.py
+++ b/emlearn/convert.py
@@ -2,13 +2,20 @@
 from . import trees
 from . import net
 from . import bayes
+from . import cgen
 
-def convert(estimator, kind=None, method='pymodule'):
+def convert(estimator, kind=None, method='pymodule', 
+            float_type=None, float_precision=None):
     """Main entrypoint for converting a model"""
+
 
     if kind is None:
         kind = type(estimator).__name__
-
+    
+    if float_type is not None:
+        cgen.FLOATING_DTYPE = float_type
+    if float_precision is not None:
+        cgen.FLOATING_PRECISION = float_precision
     # Uname instead of instance to avoid hard dependency on the libraries
     if kind in ['RandomForestClassifier', 'ExtraTreesClassifier', 'DecisionTreeClassifier']:
         return trees.Wrapper(estimator, method) 


### PR DESCRIPTION
I had some problems that the `float` precision of the MLP conversion wasn't accurate enough for my network. So I adapted a switch with which it is possible to change the dtype and the precision of the output.

e.g.
```Python
import emlearn
mlp = MLPClassifier(...)
# [...]
cmodel = emlearn.convert(mlp, float_type='float', float_precision=4)
cmodel = emlearn.convert(mlp, float_type='double', float_precision=12)
```

Maybe it's not a very beautiful implementation, but it was the way of least changes to the code.

What I did:
Added a variable to the main of `cgen`. This was the easiest way of setting the `dtype` without passing it around the 6 layers of function calls. This way we can set the dtype and precision wherever we want by changing `cgen.FLOATING_DTYPE`. At the same time I kept the main argument switch of `cgen.const` remains 'float', to keep up compatibility with custom dtypes such as 'EmlNet']


edit:
Okay, it seems to crash the BayesNet. Which is strange, because locally the test runs fine. :-/ 