### PR TITLE
fix additional Variable Array Length MCSV incompatibilities

### DIFF
--- a/emlearn/eml_bayes.h
+++ b/emlearn/eml_bayes.h
@@ -5,6 +5,9 @@
 #include "eml_common.h"
 #include "eml_fixedpoint.h"
 
+#ifndef EML_MAX_CLASSES
+#define EML_MAX_CLASSES 10
+#endif
 
 typedef struct _EmlBayesSummary {
     eml_q16_t mean;
@@ -94,8 +97,7 @@ eml_bayes_predict(EmlBayesModel *model, const float values[], int32_t values_len
    EML_PRECONDITION(values, -EmlUninitialized);
    EML_PRECONDITION(model->n_classes >= 2, -EmlUninitialized);
 
-   const int MAX_CLASSES = 10;
-   eml_q16_t class_probabilities[MAX_CLASSES];
+   eml_q16_t class_probabilities[EML_MAX_CLASSES];
 
    for (int class_idx = 0; class_idx<model->n_classes; class_idx++) {
 

--- a/emlearn/eml_benchmark.h
+++ b/emlearn/eml_benchmark.h
@@ -6,7 +6,9 @@
 
 #if defined (__unix__) || (defined (__APPLE__) && defined (__MACH__))
 // Unix-like system
+#ifndef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 199309L
+#endif
 #define EML_HAVE_SYS_TIME 1
 #endif
 
@@ -61,7 +63,7 @@ eml_benchmark_fill(float *values, int features) {
     uint32_t rng_state = 1;    
 
     for (int i=0; i<features; i++) {
-        values[i] = (int32_t)eml_lcg_parkmiller(&rng_state);
+        values[i] = (float)eml_lcg_parkmiller(&rng_state);
     }
     return EmlOk;
 }
@@ -86,7 +88,7 @@ eml_benchmark_melspectrogram(EmlAudioMel mel_params,
         sum += input.data[0];
 
         const int64_t end = eml_benchmark_micros();
-        times[i] = end - start;
+        times[i] = (float)(end - start);
     }
 
     return EmlOk;

--- a/test/bench.c
+++ b/test/bench.c
@@ -4,31 +4,33 @@
 
 #include <stdio.h>
 
+#ifndef EML_N_FFT
+#define EML_N_FFT 1024
+#define EML_N_REPS 1000
+#define EML_FRAME_LENGTH 1024
+#define EML_N_FFT_TABLE (EML_N_FFT/2)
+#endif
+
 EmlError
 bench_melspec()
 {
-    const int n_fft = 1024;
-    const int n_reps = 1000;
-    const EmlAudioMel mel = { 64, 0, 20000, n_fft, 44100 };
-    float times[n_reps];
+    const EmlAudioMel mel = { 64, 0, 20000, EML_N_FFT, 44100 };
+    float times[EML_N_REPS];
 
-    const int frame_length = 1024;
+    float input_data[EML_FRAME_LENGTH];
+    float temp_data[EML_FRAME_LENGTH];
+    eml_benchmark_fill(input_data, EML_FRAME_LENGTH);
 
-    float input_data[frame_length];
-    float temp_data[frame_length];
-    eml_benchmark_fill(input_data, frame_length);
+    float fft_sin[EML_N_FFT_TABLE];
+    float fft_cos[EML_N_FFT_TABLE];
+    EmlFFT fft = { EML_N_FFT_TABLE, fft_sin, fft_cos };
+    EML_CHECK_ERROR(eml_fft_fill(fft, EML_N_FFT));
 
-    const int n_fft_table = n_fft/2;
-    float fft_sin[n_fft_table];
-    float fft_cos[n_fft_table];
-    EmlFFT fft = { n_fft_table, fft_sin, fft_cos };
-    EML_CHECK_ERROR(eml_fft_fill(fft, n_fft));
-
-    eml_benchmark_melspectrogram(mel, fft, input_data, temp_data, n_reps, times);
-    EmlVector t = { times, n_reps };
+    eml_benchmark_melspectrogram(mel, fft, input_data, temp_data, EML_N_REPS, times);
+    EmlVector t = { times, EML_N_REPS };
 
     const float mean = eml_vector_mean(t);
-    printf("melspec;%d;%f\n", n_reps, mean);
+    printf("melspec;%d;%f\n", EML_N_REPS, mean);
     return EmlOk;
 }
 


### PR DESCRIPTION
fix additional Variable Array Length MCSV incompatibilities
Also add #ifdef guard for _POSIX_C_SOURCE

Note: in addition there are some compile time warnings that cause the test_benchmark to fail under windows. I will add all typecasting to a separate PR