### PR TITLE
MSVC compatibility changes

### DIFF
--- a/emlearn/eml_bayes.h
+++ b/emlearn/eml_bayes.h
@@ -5,6 +5,9 @@
 #include "eml_common.h"
 #include "eml_fixedpoint.h"
 
+#ifndef EML_MAX_CLASSES
+#define EML_MAX_CLASSES 10
+#endif
 
 typedef struct _EmlBayesSummary {
     eml_q16_t mean;
@@ -94,8 +97,7 @@ eml_bayes_predict(EmlBayesModel *model, const float values[], int32_t values_len
    EML_PRECONDITION(values, -EmlUninitialized);
    EML_PRECONDITION(model->n_classes >= 2, -EmlUninitialized);
 
-   const int MAX_CLASSES = 10;
-   eml_q16_t class_probabilities[MAX_CLASSES];
+   eml_q16_t class_probabilities[EML_MAX_CLASSES];
 
    for (int class_idx = 0; class_idx<model->n_classes; class_idx++) {
 

--- a/emlearn/eml_benchmark.h
+++ b/emlearn/eml_benchmark.h
@@ -6,7 +6,9 @@
 
 #if defined (__unix__) || (defined (__APPLE__) && defined (__MACH__))
 // Unix-like system
+#ifndef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 199309L
+#endif
 #define EML_HAVE_SYS_TIME 1
 #endif
 

--- a/examples/digits.py
+++ b/examples/digits.py
@@ -5,6 +5,7 @@ import numpy
 from sklearn.model_selection import train_test_split
 from sklearn.ensemble import RandomForestClassifier
 from sklearn import metrics, datasets
+import serial.tools.list_ports as port_list
 
 rnd = 11
 digits = datasets.load_digits()
@@ -32,7 +33,9 @@ code = cmodel.save(file=filename)
 
 print('Wrote C code to', filename)
 
-port = '/dev/ttyUSB0'
+assert len(port_list.comports()) > 0, "No serial ports available"
+
+port = port_list.comports()[0].device # grab the first serial port
 print('Classify on microcontroller via', port)
 import serial
 device = serial.Serial(port=port, baudrate=115200, timeout=0.1) 

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,3 +1,4 @@
+setuptools>=41.0.0
 pytest-cov>=2.5.1
 scipy>=1.0.0
 scikit-learn>=0.19.1

--- a/test/bench.c
+++ b/test/bench.c
@@ -4,31 +4,33 @@
 
 #include <stdio.h>
 
+#ifndef EML_N_FFT
+#define EML_N_FFT 1024
+#define EML_N_REPS 1000
+#define EML_FRAME_LENGTH 1024
+#define EML_N_FFT_TABLE (EML_N_FFT/2)
+#endif
+
 EmlError
 bench_melspec()
 {
-    const int n_fft = 1024;
-    const int n_reps = 1000;
-    const EmlAudioMel mel = { 64, 0, 20000, n_fft, 44100 };
-    float times[n_reps];
+    const EmlAudioMel mel = { 64, 0, 20000, EML_N_FFT, 44100 };
+    float times[EML_N_REPS];
 
-    const int frame_length = 1024;
+    float input_data[EML_FRAME_LENGTH];
+    float temp_data[EML_FRAME_LENGTH];
+    eml_benchmark_fill(input_data, EML_FRAME_LENGTH);
 
-    float input_data[frame_length];
-    float temp_data[frame_length];
-    eml_benchmark_fill(input_data, frame_length);
+    float fft_sin[EML_N_FFT_TABLE];
+    float fft_cos[EML_N_FFT_TABLE];
+    EmlFFT fft = { EML_N_FFT_TABLE, fft_sin, fft_cos };
+    EML_CHECK_ERROR(eml_fft_fill(fft, EML_N_FFT));
 
-    const int n_fft_table = n_fft/2;
-    float fft_sin[n_fft_table];
-    float fft_cos[n_fft_table];
-    EmlFFT fft = { n_fft_table, fft_sin, fft_cos };
-    EML_CHECK_ERROR(eml_fft_fill(fft, n_fft));
-
-    eml_benchmark_melspectrogram(mel, fft, input_data, temp_data, n_reps, times);
-    EmlVector t = { times, n_reps };
+    eml_benchmark_melspectrogram(mel, fft, input_data, temp_data, EML_N_REPS, times);
+    EmlVector t = { times, EML_N_REPS };
 
     const float mean = eml_vector_mean(t);
-    printf("melspec;%d;%f\n", n_reps, mean);
+    printf("melspec;%d;%f\n", EML_N_REPS, mean);
     return EmlOk;
 }
 

--- a/test/test_benchmark.py
+++ b/test/test_benchmark.py
@@ -5,27 +5,33 @@ import subprocess
 
 import pandas
 
-def compile_program(input, out):
-    args = [
-        'gcc',
-        input,
-        '-o', out,
-        '-std=c99',
-        '-O3',
-        '-g',
-        '-fno-omit-frame-pointer',
-        '-lm',
-        '-Wall',
-        '-Werror',
-        '-I./emlearn',
-    ]
-    subprocess.check_call(' '.join(args), shell=True)
+import sys
+from distutils.ccompiler import new_compiler
 
 def test_bench_melspec():
-    testdir = os.path.dirname(__file__)
+    # create a new compiler object
+    # force re-compilation even if object files exist (required)
+    cc = new_compiler(force=1)
+    output_filename = cc.executable_filename('bench')
+    
+    testdir = os.path.abspath(os.path.dirname(__file__))
     code = os.path.join(testdir, 'bench.c')
-    prog = os.path.join(testdir, 'bench')
-    compile_program(code, prog)
+    prog = os.path.join(testdir, output_filename)
+    print(prog)
+    include_dirs=["emlearn"]
+
+    if sys.platform.startswith('win'): # Windows
+        # disable warnings: C5045-QSpectre, C4996-unsafe function/var
+        cc_args = ["/Ox","/Oy-","/Wall","/WX","/wd5045","wd4996"]
+        libraries = None
+    else : # MacOS and Linux should be the same
+        cc_args = ["-O3","-fno-omit-frame-pointer","-Wall","-Werror"]
+        libraries = ["m"] # math library / libm
+
+    objects = cc.compile(sources=[code], include_dirs=include_dirs,
+     debug=1, extra_preargs=cc_args)
+    cc.link("executable", objects, output_filename=output_filename, 
+        debug=1, libraries=libraries, output_dir=testdir)
     out = subprocess.check_output([prog]).decode('utf-8')
 
     df = pandas.read_csv(io.StringIO(out), sep=';')


### PR DESCRIPTION
add setuptutils minimum to requirements (required for python 3.5)
variable array length fixes for MSVC compilers
change gcc shell calls to distutils calls for compilation
(as per PR#18)