### PR TITLE
trees: Fix formatting of ints in inline inference strategy

### DIFF
--- a/emlearn/cgen.py
+++ b/emlearn/cgen.py
@@ -48,6 +48,8 @@ def constant(val, dtype='float'):
     """
     if dtype == 'float':
         return "{:.6f}f".format(val)
+    elif 'int' in dtype:
+        return "{:d}".format(int(val))
     else:
         return str(val)
 

--- a/emlearn/trees.py
+++ b/emlearn/trees.py
@@ -246,7 +246,7 @@ def generate_c_inlined(forest, name, dtype='float', classifier=True):
         {right}
         {indent}}}""".format(**{
             'feature': n[0],
-            'value': n[1],
+            'value': cgen.constant(n[1], dtype=dtype),
             'left': c_node(n[2], depth+1),
             'right': c_node(n[3], depth+1),
             'indent': depth*indent*' ',

--- a/examples/trees-feature-quantization-avr8.csv
+++ b/examples/trees-feature-quantization-avr8.csv
@@ -1,6 +1,6 @@
 dtype,program,data
-float,7358,240
-int32_t,9042,240
-int16_t,4614,120
-int8_t,2594,60
-uint8_t,2590,60
+float,7300,240
+int32_t,6362,240
+int16_t,3958,120
+int8_t,2558,60
+uint8_t,2554,60


### PR DESCRIPTION
We were actually formatting the thresholds as floats. This happened because scikit-learn always returns floats, so we need to explicitly cast.