### PR TITLE
Raise descriptive error when going beyong number of supported nodes

### DIFF
--- a/test/test_trees.py
+++ b/test/test_trees.py
@@ -9,6 +9,7 @@ from sklearn.ensemble import ExtraTreesClassifier, ExtraTreesRegressor
 from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
 
 import emlearn
+from emlearn.evaluate.trees import model_size_nodes
 import pytest
 
 random = numpy.random.randint(0, 1000)
@@ -67,6 +68,20 @@ def test_trees_sklearn_regressor_predict(data, model, method):
 
     numpy.testing.assert_allclose(pred_c, pred_original, rtol=1e-3, atol=2)
 
+
+def test_trees_too_many_nodes():
+    """should give nice error"""
+    X, Y = datasets.make_classification(n_classes=2, n_samples=1000, random_state=1)
+    estimator = RandomForestClassifier(n_estimators=1000, max_depth=20, random_state=1)
+    estimator.fit(X, Y)
+
+    with pytest.raises(ValueError) as ex:
+        cmodel = emlearn.convert(estimator, method='loadable')
+
+    error = str(ex.value).lower()
+    assert 'nodes' in error
+    assert 'model has ' in error
+    assert 'max supported ' in error
 
 def test_deduplicate_single_tree():
     nodes = [


### PR DESCRIPTION
Currently emltrees are limited to 2**15 =32768 nodes total. This is due to absolute indexing being used for children and EmlTreesNode having int16_t data-type. This ensures that we at least give a clear error when attempting to go bigger than this.

Using relative jumps would help lift this limitation, without having to increase the size of the nodes. But due to the leaf node de-duplication there are jumps "across" individual trees for leaves. So we would have to treat leaf nodes differently for this to be possible. There are some starts on that in #62 