### PR TITLE
Basic Platform IO Compatibility

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,0 +1,8 @@
+{
+    "name":"emlearn",
+    "version": "0.20.4",
+    "build": {
+        "srcDir": "emlearn",
+        "srcFilter": "+<*.h> -<arduino> -<evaluate> -<examples> -<platforms> -<preprocessing> -<templates> -<tools> -<utils>"
+    }
+}


### PR DESCRIPTION
This is a single commit that adds a `library.json` file. This file allows this repository to be used in Platform IO (PIO) projects as a dependency.
With this file in the repository it can then be added as a dependency to any PIO project using the `lib_deps` field of the `platformio.ini` file for the project.

Example `platformio.ini` contents for use with an ESP32 pico.

```.ini
[env:pico32]
platform = espressif32
board = pico32
framework = arduino

lib_deps = 
	https://github.com/emlearn/emlearn.git
```

More information about Platform IO can be found here:
https://platformio.org/