### PR TITLE
trees: Switch to using int16 for features

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -21,6 +21,7 @@ jobs:
 
       - name: Install OS dependencies
         run: |
+          sudo apt-get update
           sudo apt-get install -yqq libsndfile1 libsndfile1-dev
       - name: Install Python dependencies
         run: |
@@ -67,6 +68,7 @@ jobs:
 
       - name: Install OS dependencies
         run: |
+          sudo apt-get update
           sudo apt-get install -yqq libsndfile1 libsndfile1-dev doxygen
       - name: Install Python dependencies
         run: |
@@ -103,6 +105,7 @@ jobs:
 
       - name: Install OS dependencies
         run: |
+          sudo apt-get update
           sudo apt-get install -yqq libsndfile1 libsndfile1-dev arduino arduino-core-avr
 
       - name: Install Arduino CLI
@@ -144,8 +147,8 @@ jobs:
 
       - name: Install OS dependencies
         run: |
-          sudo apt-get install -yqq libsndfile1 libsndfile1-dev
           sudo apt-get update
+          sudo apt-get install -yqq libsndfile1 libsndfile1-dev
           sudo apt-get install --no-install-recommends git cmake ninja-build gperf \
             ccache dfu-util device-tree-compiler wget \
             python3-dev python3-pip python3-setuptools python3-tk python3-wheel xz-utils file \

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ cmodel.save(file='sonar.h', name='sonar')
 #include "sonar.h"
 
 const int32_t length = 60;
-float values[length] = { ... };
+int16_t values[length] = { ... };
 
 // using generated "inline" code for the decision forest
 const int32_t predicted_class = sonar_predict(values, length):

--- a/docs/helloworld_xor/helloworld_xor.ino
+++ b/docs/helloworld_xor/helloworld_xor.ino
@@ -14,12 +14,12 @@ void setup() {
   pinMode(digitalPinB, INPUT_PULLUP); 
 }
 
-// Read values into range 0.0-1.0
-float readAnalog(const int pin) {
-    return analogRead(pin) / 1023.0;
+// Read values into range 0-255
+uint8_t readAnalog(const int pin) {
+    return analogRead(pin) / (1023/255);
 }
-float readDigital(const int pin) {
-    return digitalRead(pin) ? 1.0 : 0.0;
+uint8_t readDigital(const int pin) {
+    return digitalRead(pin) ? 255 : 0;
 }
 
 
@@ -27,14 +27,14 @@ void loop() {
 
 #if 1
   // use digital pins
-  const float a = readDigital(digitalPinA);
-  const float b = readDigital(digitalPinB);
+  const uint8_t a = readDigital(digitalPinA);
+  const uint8_t b = readDigital(digitalPinB);
 #else
   // use analog pins
-  const float a = readAnalog(analogPinA);
-  const float b = readAnalog(analogPinB);
+  const uint8_t a = readAnalog(analogPinA);
+  const uint8_t b = readAnalog(analogPinB);
 #endif
-  const float features[] = { a, b };
+  const int16_t features[] = { a, b };
 
   const int32_t out = xor_model_predict(features, 2);
 

--- a/docs/helloworld_xor/xor_browser.c
+++ b/docs/helloworld_xor/xor_browser.c
@@ -8,15 +8,17 @@ int
 run_xor_model(const float *features, int length)
 {
     int out = -EmlSizeMismatch;
-    float a = -1.0;
-    float b = -1.0;
     if (length == 2) {
-        a = features[0];
-        b = features[1];
-        out = xor_model_predict(features, length); // Alternative A: "inline"
-        out = eml_trees_predict(&xor_model, features, length); // Alternative B: "loadable"
+        // model uses 0-255 range internally
+        const int16_t *quantized = { features[0]*255, features[1]*255 };
+        out = xor_model_predict(quantized, length); // Alternative A: "inline"
+        out = eml_trees_predict(&xor_model, quantized, length); // Alternative B: "loadable"
+    } else {
+        printf("run_xor_model-incorrect-length n_features=%d expected=2", length);
+        return -1;
     }
 
-    printf("run_xor_model n_features=%d inputs=(%.2f, %.2f) out=%d\n", length, a, b, out);
-    return out; 
+    printf("run_xor_model n_features=%d inputs=(%.2f, %.2f) out=%d\n",
+        length, features[0], features[1], out);
+    return out;
 }

--- a/docs/helloworld_xor/xor_host.c
+++ b/docs/helloworld_xor/xor_host.c
@@ -13,7 +13,8 @@ main(int argc, const char *argv[])
 
     const float a = strtod(argv[1], NULL);
     const float b = strtod(argv[2], NULL);
-    const float features[] = { a, b };
+    // Model uses 8 bit scaling of 0.0-1.0 range internally
+    const int16_t features[] = { a*255, b*255 };
 
     int out = xor_model_predict(features, 2); // Alternative A: "inline"
     out = eml_trees_predict(&xor_model, features, 2); // Alternative B: "loadable"

--- a/docs/helloworld_xor/xor_train.py
+++ b/docs/helloworld_xor/xor_train.py
@@ -8,6 +8,8 @@ def make_xor(lower=0.0, upper=1.0, threshold=0.5, samples=100, seed=42):
     rng = numpy.random.RandomState(seed)
     X = rng.uniform(lower, upper, size=(samples, 2))
     y = numpy.logical_xor(X[:, 0] > threshold, X[:, 1] > threshold)
+    # convert to int16 with a 8 bit range. [0.0-1.0] -> [0-255]
+    X = (X * 255).astype(numpy.int16)
     return X, y
 
 X, y = make_xor()

--- a/emlearn/common.py
+++ b/emlearn/common.py
@@ -52,16 +52,16 @@ def build_classifier(cmodel, name, temp_dir, include_dir, func=None, test_functi
         # be strict about compile warning
         cc_args += [ '-Wall', '-Werror', '-Wno-error=unused-variable' ]
 
-    if n_classes is not None:
+    if n_classes:
         code = """
         #include "{def_file_name}"
         #include <eml_test.h>
 
         #define N_CLASSES {n_classes}
-        float outputs[N_CLASSES];
+        float outputs[N_CLASSES] = {{0.0}};
 
         static void classify_proba(const float *values, int length, int row) {{
-            const EmlError err = {func};
+            {func}; // TODO: handle error
             for (int class_no=0; class_no<N_CLASSES; class_no++) {{
                 const float prob = outputs[class_no];
                 printf("%d,%d,%f\\n", row, class_no, prob);

--- a/emlearn/convert.py
+++ b/emlearn/convert.py
@@ -47,7 +47,7 @@ class Model():
 def convert(estimator, 
         kind : str = None,
         method: str = 'loadable',
-        dtype: str ='float',
+        dtype: str = None,
         return_type: str = 'classifier',
         **kwargs,
         ) -> Model:
@@ -68,8 +68,12 @@ def convert(estimator,
         # return_type is intentionally not passed through - the Wrapper will guess based on Class name
         return trees.Wrapper(estimator, method, dtype=dtype, **kwargs)
     elif kind in ['EllipticEnvelope']:
+        if dtype is None:
+            dtype = 'float'
         return distance.Wrapper(estimator, method, dtype=dtype)
     elif kind in ['GaussianMixture', 'BayesianGaussianMixture']:
+        if dtype is None:
+            dtype = 'float'
         return mixture.Wrapper(estimator, method, dtype=dtype)
     elif kind in ('MLPClassifier', 'MLPRegressor'):
         return net.convert_sklearn_mlp(estimator, method, return_type=return_type, **kwargs)

--- a/emlearn/eml_trees.h
+++ b/emlearn/eml_trees.h
@@ -2,6 +2,10 @@
 #ifndef EML_TREES_H
 #define EML_TREES_H
 
+#ifndef EML_TREES_TRACE
+#define EML_TREES_TRACE 0
+#endif
+
 #ifndef EML_TREES_REGRESSION_ENABLE
 #define EML_TREES_REGRESSION_ENABLE 1
 #endif
@@ -79,6 +83,12 @@ eml_trees_predict_tree(const EmlTrees *forest, int32_t tree_root,
         const int16_t point = forest->nodes[node_idx].value;
         //printf("node %d feature %d. %d < %d\n", node_idx, feature, value, point);
         const int16_t child = (value < point) ? forest->nodes[node_idx].left : forest->nodes[node_idx].right;
+    
+#if EML_TREES_TRACE
+        EML_LOG_PRINTF("predit-tree-iter node=%d feature=%d value=%d th=%d next=%d \n",
+            node_idx, feature, value, point, child);
+#endif
+
         if (child >= 0) {
             node_idx += child;
         } else {
@@ -87,6 +97,12 @@ eml_trees_predict_tree(const EmlTrees *forest, int32_t tree_root,
     }
 
     const int16_t leaf = -node_idx-1;
+
+    EML_LOG_BEGIN("eml-trees-predict-tree-end");
+    EML_LOG_ADD_INTEGER("node", node_idx);
+    EML_LOG_ADD_INTEGER("leaf", leaf);
+    EML_LOG_END();
+
     return leaf;
 }
 

--- a/emlearn/eml_trees.h
+++ b/emlearn/eml_trees.h
@@ -16,7 +16,7 @@ extern "C" {
 
 typedef struct _EmlTreesNode {
     int8_t feature;
-    float value;
+    int16_t value;
     int16_t left;
     int16_t right;
 } EmlTreesNode;
@@ -68,15 +68,15 @@ Returns an offset into the leaves structure
 */
 static int32_t
 eml_trees_predict_tree(const EmlTrees *forest, int32_t tree_root,
-                    const float *features, int8_t features_length)
+                        const int16_t *features, int8_t features_length)
 {
     int32_t node_idx = tree_root;
 
     // TODO: see if using a pointer node instead of indirect adressing using node_idx improves perf
     while (node_idx >= 0) {
         const int8_t feature = forest->nodes[node_idx].feature;
-        const float value = features[feature];
-        const float point = forest->nodes[node_idx].value;
+        const int16_t value = features[feature];
+        const int16_t point = forest->nodes[node_idx].value;
         //printf("node %d feature %d. %d < %d\n", node_idx, feature, value, point);
         const int16_t child = (value < point) ? forest->nodes[node_idx].left : forest->nodes[node_idx].right;
         if (child >= 0) {
@@ -100,7 +100,7 @@ eml_trees_outputs_proba(const EmlTrees *self)
 
 EmlError
 eml_trees_predict_proba(const EmlTrees *self,
-            const float *features, int8_t features_length,
+            const int16_t *features, int8_t features_length,
             float *out, int32_t out_length)
 {
     EML_PRECONDITION(features, EmlUninitialized);
@@ -174,7 +174,7 @@ eml_trees_predict_proba(const EmlTrees *self,
 * \return The class number, or -EmlTreesError on failure
 */
 int32_t
-eml_trees_predict(const EmlTrees *forest, const float *features, int8_t features_length)
+eml_trees_predict(const EmlTrees *forest, const int16_t *features, int8_t features_length)
 {
     EML_LOG_BEGIN("eml-trees-predict-start");
     EML_LOG_ADD_INTEGER("classes", forest->n_classes);
@@ -233,7 +233,7 @@ eml_trees_predict(const EmlTrees *forest, const float *features, int8_t features
 */
 EmlError
 eml_trees_regress(const EmlTrees *forest,
-        const float *features, int8_t features_length,
+        const int16_t *features, int8_t features_length,
         float *out, int8_t out_length)
 {
 
@@ -283,7 +283,7 @@ eml_trees_regress(const EmlTrees *forest,
 */
 float
 eml_trees_regress1(const EmlTrees *forest,
-        const float *features, int8_t features_length)
+        const int16_t *features, int8_t features_length)
 {
     float out[1];
     EmlError err = eml_trees_regress(forest,

--- a/emlearn/trees.py
+++ b/emlearn/trees.py
@@ -485,7 +485,7 @@ def generate_c_loadable(forest, name, n_features,
 
 
 class Wrapper:
-    def __init__(self, estimator, classifier, dtype='float', leaf_bits=None):
+    def __init__(self, estimator, classifier, dtype='int16_t', leaf_bits=None):
 
         self.dtype = dtype
 
@@ -535,30 +535,104 @@ class Wrapper:
         if self._classifier is not None:
             return None
 
-        method = self.method
-        if method == 'loadable':
-            name = 'mytree'
-            proba_func = 'eml_trees_predict_proba(&{}, values, length, outputs, N_CLASSES)'\
-                .format(name, self.n_classes)
+        name = 'mytree'
+        n_features = self.n_features
+        n_classes = self.n_classes
+        feature_dtype = self.dtype
 
-            if self.is_classifier:
-                func = 'eml_trees_predict(&{}, values, length)'.format(name)
-            else:
-                func = 'eml_trees_regress1(&{}, values, length)'.format(name)
-            code = self.save(name=name)
-            self.classifier_ = common.CompiledClassifier(code, name=name,
-                call=func, proba_call=proba_func, out_dtype=self.out_dtype, n_classes=self.n_classes)
-        elif method == 'inline':
-            name = 'myinlinetree'
-            # TODO: actually implement inline predict_proba, instead of just using loadable
-            proba_func = 'eml_trees_predict_proba(&{}, values, length, outputs, N_CLASSES)'\
-                .format(name, self.n_classes)
-            func = '{}_predict(values, length)'.format(name)
-            code = self.save(name=name)
-            self.classifier_ = common.CompiledClassifier(code, name=name,
-                call=func, proba_call=proba_func, out_dtype=self.out_dtype, n_classes=self.n_classes)
+        model_init = self.save(name=name)
+
+        code = '\n'.join([
+            model_init,
+
+            # Floating point wrappers for loadable, that is compatible with CompilerClassifier
+            f"""
+            int32_t
+            predict_loadable(const float *values, int length) {{
+                 // Convert to integer
+                int16_t features[{n_features}];
+                for (int i=0; i<length; i++) {{
+                    features[i] = (int16_t)values[i];
+                }}
+                const int out = eml_trees_predict(&{name}, features, length);
+                if (out < 0) {{
+                    return -out;
+                }}
+                return out;
+            }}
+            """,
+            # Floating point wrappers for inline, that is compatible with CompilerClassifier
+            f"""
+            int32_t
+            predict_inline(const float *values, int length) {{
+                // Convert to whatever is needed for inline
+                {feature_dtype} features[{n_features}];
+                for (int i=0; i<length; i++) {{
+                    features[i] = ({feature_dtype})values[i];
+                }}
+                const int out = {name}_predict(features, length);
+                if (out < 0) {{
+                    return -out;
+                }}
+                return out;
+            }}
+            """,
+            # Floating point wrappers for proba, that is compatible with CompilerClassifier
+            f"""
+            EmlError
+            predict_proba(const float *values, int length, float *outputs, int n_outputs) {{
+                // Convert to integer
+                int16_t features[{n_features}];
+                for (int i=0; i<length; i++) {{
+                    features[i] = (int16_t)values[i];
+                }}
+
+                
+                const EmlError err = \
+                    eml_trees_predict_proba(&{name}, features, length, outputs, n_outputs);
+
+                return err;
+            }}
+            """,
+            # Floating point wrappers for regress, that is compatible with CompilerClassifier
+            f"""
+            int32_t
+            regress_func(const float *values, int length) {{
+                // Convert to integer
+                int16_t features[{n_features}];
+                for (int i=0; i<length; i++) {{
+                    features[i] = (int16_t)values[i];
+                }}
+                const float out = eml_trees_regress1(&{name}, features, length);
+                return out;
+            }}
+            """
+        ])
+
+        #with open('treegen.h', 'w') as f:
+        #    f.write(code)
+
+        # TODO: actually implement inline predict_proba, instead of just using loadable
+        proba_func = 'predict_proba(values, length, outputs, N_CLASSES)'
+        regress_func = 'regress_func(values, length)'
+
+        if self.method == 'loadable':
+            predict_func = 'predict_loadable(values, length)'
+        elif self.method == 'inline':
+            predict_func = 'predict_inline(values, length)'
         else:
             assert False, 'should not happen, constructor should enforce'
+
+        if self.is_classifier:
+            call_func = predict_func
+        else:
+            call_func = regress_func
+            proba_func = None
+
+        self.classifier_ = common.CompiledClassifier(code, name=name,
+            call=call_func, proba_call=proba_func,
+            out_dtype=self.out_dtype, n_classes=self.n_classes,
+        )
 
 
     def predict(self, X):

--- a/emlearn/trees.py
+++ b/emlearn/trees.py
@@ -488,6 +488,8 @@ class Wrapper:
     def __init__(self, estimator, classifier, dtype='int16_t', leaf_bits=None):
 
         self.dtype = dtype
+        if self.dtype is None:
+            self.dtype = 'int16_t'
 
         kind = type(estimator).__name__
         leaf = 'argmax'

--- a/examples/xor.c
+++ b/examples/xor.c
@@ -11,9 +11,12 @@ main(int argc, const char *argv[])
         return -1;
     }
 
+    // Input is espected to be 0.0-255.0
     const float a = strtod(argv[1], NULL);
     const float b = strtod(argv[2], NULL);
-    const float features[] = { a, b };
+
+    // Convert to integers
+    const int16_t features[] = { a, b };
 
     const int out = xor_predict(features, 2);
     if (out < 0) {

--- a/examples/xor.py
+++ b/examples/xor.py
@@ -43,7 +43,7 @@ def make_noisy_xor(seed=42):
     flip = rng.randint(300, size=15)
     y[flip] = ~y[flip]
 
-    df = pandas.DataFrame(X)
+    df = pandas.DataFrame((X * 255).astype(numpy.int16))
     df['label'] = y
 
     return df

--- a/platform_examples/zephyr/helloworld_xor/src/main.c
+++ b/platform_examples/zephyr/helloworld_xor/src/main.c
@@ -8,15 +8,15 @@
 
 void xor_test(void)
 {
-    const float test_inputs[4][2] = {
-        { 0.0f, 0.0f },
-        { 1.0f, 0.0f },
-        { 0.0f, 1.0f },
-        { 1.0f, 1.0f },
+    const int16_t test_inputs[4][2] = {
+        { 0,    0   },
+        { 255,  0   },
+        { 0,    255 },
+        { 255,  255 },
     };
 
     for (int i=0; i<4; i++) {
-        const float *features = test_inputs[i];
+        const int16_t *features = test_inputs[i];
         const int out = xor_model_predict(features, 2);
 
         printf("xor(%d,%d) = %d\n", (int)features[0], (int)features[1], out);

--- a/test/test_all.c
+++ b/test/test_all.c
@@ -9,6 +9,7 @@
 #include "test_array.c"
 #include "test_neighbors.c"
 #include "test_quantizer.c"
+#include "test_trees.c"
 #include "test_net.c"
 
 #include <unity.c>
@@ -21,12 +22,13 @@ typedef struct _TestModule {
     TestModuleFunction func;
 } TestModule;
 
-#define TEST_MODULES 4
+#define TEST_MODULES 5
 TestModule test_modules[TEST_MODULES] = {
     { "array", test_eml_array },
     { "neighbors", test_eml_neighbors },
     { "quantizer", test_eml_quantizer },
     { "net", test_eml_net },
+    { "trees", test_eml_trees },
 };
 
 void

--- a/test/test_neighbors.py
+++ b/test/test_neighbors.py
@@ -1,5 +1,6 @@
 
 import emlearn
+from emlearn.preprocessing import Quantizer
 
 import pytest
 import sklearn
@@ -55,8 +56,10 @@ def make_classification_dataset(n_features=10, n_classes=10):
                                n_redundant=0, n_informative=n_features,
                                random_state=rng, n_clusters_per_class=3, n_samples=50)
     X += 2 * rng.uniform(size=X.shape)
+
     X = StandardScaler().fit_transform(X)
-    X = numpy.clip(1000*X, -32768, 32767).astype(int) # convert to int16 range
+    # FIXME: fails when values are larger
+    X = Quantizer(out_max=10000).fit_transform(X)
 
     X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=.2)
     return X_train, X_test, y_train, y_test

--- a/test/test_neighbors.py
+++ b/test/test_neighbors.py
@@ -68,6 +68,7 @@ SUPPORTED_PARAMS = {
     'default': dict(),
     'metric=euclidean': dict(metric='euclidean'),
     'NN1': dict(n_neighbors=1),
+    'NN5': dict(n_neighbors=5),
 }
 
 @pytest.mark.parametrize('params', SUPPORTED_PARAMS)

--- a/test/test_trees.c
+++ b/test/test_trees.c
@@ -1,0 +1,75 @@
+
+
+#define EML_NET_LOG_LEVEL 1
+#include <eml_trees.h>
+
+#include <unity.h>
+
+#define TEST_XOR_FEATURES 2
+#define TEST_XOR_ROWS 4
+#define TEST_BUFFER_LENGTH 10
+
+void
+test_trees_xor_predict()
+{
+    // Basic check that we can discriminate between data from two different classes
+    EmlError err = EmlOk;
+    int16_t out_label = -1;
+
+    float buffer1[TEST_BUFFER_LENGTH];
+    float buffer2[TEST_BUFFER_LENGTH];
+
+    // Setup XOR model, single decision tree
+    int32_t roots[1] = { 0 };
+    uint8_t leaves[2] = { 0, 1 };
+    EmlTreesNode nodes[] = {
+        // feature, value, left, right
+        { 0, 0, 1, 2 },
+        { 1, 0, -1, -2 },
+        { 1, 0, -2, -1 },
+    };
+    EmlTrees _model;
+    EmlTrees *model = &_model;
+
+    model->n_nodes = 3;
+    model->nodes = nodes;
+    model->n_trees = 1;
+    model->tree_roots = roots;
+    model->n_leaves = 2;
+    model->leaves = leaves;
+    model->leaf_bits = 0; // majority voting
+    model->n_features = 2;
+    model->n_classes = 2;
+
+    // Test data
+    int16_t test_data[TEST_XOR_ROWS][TEST_XOR_FEATURES+1] = {
+        // in1, in2 -> out 
+        { -1, -1,  0 },
+        {  1,  1,  0 },
+        { -1,  1,  1 },
+        {  1, -1,  1 },
+    };
+
+    float out[2];
+
+    for (int i=0; i<TEST_XOR_ROWS; i++) {
+        const int16_t *data = test_data[i];
+        const int16_t expect_class = data[2];   
+
+        printf("test-xor case=%d in=[%d %d] expect=%d\n", i, data[0], data[1], expect_class);
+
+        const EmlError err = eml_trees_predict_proba(model, data, TEST_XOR_FEATURES, out, 2);
+        TEST_ASSERT_EQUAL(EmlOk, err);
+        // FIXME: check probabiltities;
+
+        const int out = eml_trees_predict(model, data, TEST_XOR_FEATURES);
+        TEST_ASSERT_EQUAL(out, expect_class);        
+    }
+}
+
+void
+test_eml_trees()
+{
+    // Add tests here
+    RUN_TEST(test_trees_xor_predict);
+}

--- a/test/test_trees.c
+++ b/test/test_trees.c
@@ -55,15 +55,18 @@ test_trees_xor_predict()
     for (int i=0; i<TEST_XOR_ROWS; i++) {
         const int16_t *data = test_data[i];
         const int16_t expect_class = data[2];   
+        const float expect_proba0 = (expect_class == 0) ? 1.0f : 0.0f;
+        const float expect_proba1 = (expect_class == 0) ? 0.0f : 1.0f;
 
         printf("test-xor case=%d in=[%d %d] expect=%d\n", i, data[0], data[1], expect_class);
 
         const EmlError err = eml_trees_predict_proba(model, data, TEST_XOR_FEATURES, out, 2);
         TEST_ASSERT_EQUAL(EmlOk, err);
-        // FIXME: check probabiltities;
+        TEST_ASSERT_FLOAT_WITHIN(0.01f, expect_proba0, out[0]);
+        TEST_ASSERT_FLOAT_WITHIN(0.01f, expect_proba1, out[1]);
 
         const int out = eml_trees_predict(model, data, TEST_XOR_FEATURES);
-        TEST_ASSERT_EQUAL(out, expect_class);        
+        TEST_ASSERT_EQUAL(out, expect_class);
     }
 }
 

--- a/test/test_trees.py
+++ b/test/test_trees.py
@@ -15,6 +15,7 @@ import sklearn.model_selection
 import sklearn.metrics
 import scipy.stats
 
+from emlearn.preprocessing import Quantizer
 import emlearn
 from emlearn.evaluate.trees import model_size_nodes, tree_depth_average
 import pytest
@@ -86,6 +87,7 @@ def check_csv_export(cmodel):
 def test_trees_sklearn_classifier_predict(data, model, method):
     X, y = CLASSIFICATION_DATASETS[data]
     estimator = CLASSIFICATION_MODELS[model]
+    X = Quantizer().fit_transform(X)
 
     estimator.fit(X, y)
     cmodel = emlearn.convert(estimator, method=method)
@@ -106,6 +108,7 @@ def test_trees_sklearn_classifier_predict(data, model, method):
 def test_trees_sklearn_regressor_predict(data, model, method):
     X, y = REGRESSION_DATASETS[data]
     estimator = REGRESSION_MODELS[model]
+    X = Quantizer().fit_transform(X)
 
     estimator.fit(X, y)
     cmodel = emlearn.convert(estimator, method=method)

--- a/test/test_trees.py
+++ b/test/test_trees.py
@@ -258,6 +258,7 @@ def test_trees_deep(method, deep_trees_model):
     """Should work just the same as a smaller model"""
     X, Y, estimator = deep_trees_model
 
+    X = X[0:1000, :]
     cmodel = emlearn.convert(estimator, method=method)
     pred_original = estimator.predict(X)
     pred_c = cmodel.predict(X)

--- a/test/test_trees.py
+++ b/test/test_trees.py
@@ -217,6 +217,7 @@ def test_trees_single_leaf_tree():
 def huge_trees_model():
     store_classifier_path = os.path.join(here, 'out/test_trees_huge.model.pickle')
     X, Y = datasets.make_classification(n_classes=2, n_samples=1000, random_state=1)
+    X = Quantizer().fit_transform(X)
     est = RandomForestClassifier(n_estimators=1000, max_depth=20, random_state=1)
     est.fit(X, Y)
 
@@ -241,6 +242,7 @@ def test_trees_huge(method, huge_trees_model):
 def deep_trees_model():
     store_classifier_path = os.path.join(here, 'out/test_trees_huge.model.pickle')
     X, Y = datasets.make_classification(n_classes=30, n_features=120, n_informative=100, n_samples=10000, random_state=1)
+    X = Quantizer().fit_transform(X)
     est = RandomForestClassifier(n_estimators=2, random_state=1)
     est.fit(X, Y)
 


### PR DESCRIPTION
So far only the "inline" inference strategy has supported.

Testing has shown that integer based linear quantization of features results in little to no loss in predictive performance.

Benefits of the change

- Significantly improves execution speed and code size on platforms without an FPU (Cortex M0 etc).
- Reduces model size from 12 to 8 bytes per node on 32 bit platforms (due to word-packing/alignment).
- Avoids converting to floating point when the input features were integers in the first place
- Reduces feature vector size by half

How to quantize

When one has floating point values as input, one needs to decide on how to quantize it. In most cases taking the maximum absolute that needs to be represented and dividing by 32767 is sufficient.
In cases where different features have very different ranges, using normalization first (with StandardScaler / MinMaxScaler / RobustScaler etc) may be beneficial.
In the rare case where large dynamic range and high precision values are needed, a non-linear transformation is advised. Such as a sqrt / log2 / log10, etc.

TODOs

- [x] Switch the feature representation to int16_t
- [x] Make all tests pass
- [x] Update examples and make docs build pass
- [x] Update documentation to use integers
- [ ] Give warning or exception on out-of-range values