### PR TITLE
fix `ModuleNotFoundError: No module named 'distutils'` in python version > 3.12

### DIFF
--- a/emlearn/common.py
+++ b/emlearn/common.py
@@ -8,7 +8,7 @@ import os
 import sys
 import subprocess
 import platform
-from distutils.ccompiler import new_compiler
+from setuptools import distutils
 
 import numpy
 
@@ -33,7 +33,7 @@ def build_classifier(cmodel, name, temp_dir, include_dir, func=None, test_functi
 
     # create a new compiler object
     # force re-compilation even if object files exist (required)
-    cc = new_compiler(force=1)
+    cc = _distutils.new_compiler(force=1)
 
     tree_name = name
     def_file_name = name+'.h'


### PR DESCRIPTION

`distutils` is deprecated since python version 3.12, this is a temporary patch to avoid `ModuleNotFoundError: No module named 'distutils'` errors

details:
https://docs.python.org/3/whatsnew/3.12.html#summary-release-highlights
> [PEP 632](https://peps.python.org/pep-0632/): Remove the distutils package. See [the migration guide](https://peps.python.org/pep-0632/#migration-advice) for advice replacing the APIs it provided. The third-party [Setuptools](https://setuptools.pypa.io/en/latest/deprecated/distutils-legacy.html) package continues to provide distutils, if you still require it in Python 3.12 and beyond.
