### PR TITLE
Fix double warnings

### DIFF
--- a/emlearn/common.py
+++ b/emlearn/common.py
@@ -97,7 +97,7 @@ def build_classifier(cmodel, name, temp_dir,
         #include <eml_test.h>
 
         static void classify(const float *values, int length, int row) {{
-            printf("%d,%f\\n", row, (float){func});
+            printf("%d,%f\\n", row, (double){func});
         }}
         int main() {{
             {test_function}(stdin, classify);

--- a/emlearn/distance.py
+++ b/emlearn/distance.py
@@ -73,7 +73,7 @@ def generate_code(means, precision, offset, name='my_elliptic', modifiers='stati
     // Data definitions
     {modifiers} EmlEllipticEnvelope {classifier_name} = {{
         {n_features},
-        {decision_boundary},
+        {decision_boundary}f,
         {means_name},
         {precisions_name}
     }};

--- a/emlearn/eml_distance.h
+++ b/emlearn/eml_distance.h
@@ -59,7 +59,7 @@ typedef struct _EmlEllipticEnvelope {
 * \param out_dist Return location for the continious outlier score (Mahalanobis distance)
 * \return 1 for outlier, 0 for inlier
 */
-float
+int
 eml_elliptic_envelope_predict(const EmlEllipticEnvelope *self,
                             const float *features, int n_features,
                             float *out_dist)

--- a/emlearn/eml_net.h
+++ b/emlearn/eml_net.h
@@ -315,7 +315,7 @@ eml_net_predict_proba(EmlNet *model, const float *features, int32_t features_len
         }
     }
 
-    EML_POSTCONDITION(fabs(proba_sum - 1.0) < 0.001, EmlPostconditionFailed);
+    EML_POSTCONDITION(fabsf(proba_sum - 1.0f) < 0.001f, EmlPostconditionFailed);
 
     return EmlOk;
 }

--- a/emlearn/eml_trees.h
+++ b/emlearn/eml_trees.h
@@ -138,7 +138,7 @@ eml_trees_predict_proba(const EmlTrees *self,
             const int32_t leaf_number = eml_trees_predict_tree(self, self->tree_roots[i], features, features_length);
             const uint8_t *leaf_data = self->leaves + leaf_number;
             const int32_t class_no = *leaf_data;
-            out[class_no] += 1.0;
+            out[class_no] += 1.0f;
         }
 
 
@@ -216,7 +216,7 @@ eml_trees_predict(const EmlTrees *forest, const int16_t *features, int8_t featur
     }
 
     int32_t most_voted_class = -1;
-    float most_voted_value = 0.0;
+    float most_voted_value = 0.0f;
     for (int32_t i=0; i<n_classes; i++) {
         //printf("votes[%d]: %d\n", i, votes[i]);
         if (votes[i] > most_voted_value) {

--- a/emlearn/trees.py
+++ b/emlearn/trees.py
@@ -367,7 +367,7 @@ def generate_c_inlined(forest, name, n_features, n_classes=0, leaf_bits=0, dtype
 
 
     def tree_func(name, root, return_type='int32_t'):
-        return """static inline int32_t {function_name}(const {ctype} *features, int32_t features_length) {{
+        return """static inline {return_type} {function_name}(const {ctype} *features, int32_t features_length) {{
         {code}
         }}
         """.format(**{
@@ -544,6 +544,8 @@ class Wrapper:
 
         model_init = self.save(name=name)
 
+        return_type = 'int32_t' if self.is_classifier else 'float'
+
         code = '\n'.join([
             model_init,
 
@@ -565,14 +567,14 @@ class Wrapper:
             """,
             # Floating point wrappers for inline, that is compatible with CompilerClassifier
             f"""
-            int32_t
+            {return_type}
             predict_inline(const float *values, int length) {{
                 // Convert to whatever is needed for inline
                 {feature_dtype} features[{n_features}];
                 for (int i=0; i<length; i++) {{
                     features[i] = ({feature_dtype})values[i];
                 }}
-                const int out = {name}_predict(features, length);
+                const {return_type} out = {name}_predict(features, length);
                 if (out < 0) {{
                     return -out;
                 }}

--- a/emlearn/trees.py
+++ b/emlearn/trees.py
@@ -598,7 +598,7 @@ class Wrapper:
             """,
             # Floating point wrappers for regress, that is compatible with CompilerClassifier
             f"""
-            int32_t
+            float
             regress_func(const float *values, int length) {{
                 // Convert to integer
                 int16_t features[{n_features}];


### PR DESCRIPTION
This happened when trying to build emlearn-micropython as MicroPython user C module, since that enables some more warnings than we have. The warnings are pretty sane, so we enable the same, and fix them.