### PR TITLE
setup: Disable building extensions by default

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -37,6 +37,8 @@ jobs:
       - name: Test in-tree code with pytest
         env:
           PYTHONPATH: ./:./build/lib.linux-x86_64-cpython-310
+          EMLEARN_BUILD_EXTENSIONS: 1
+
         run: |
           python setup.py build
           pytest -v --cov=emlearn --cov-report html --cov-report term-missing --cov-branch test/

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,8 @@ with open(os.path.join(here, 'emlearn/VERSION.txt')) as version_file:
 
 project_dir = os.path.abspath(os.path.dirname(__file__))
 
+enable_extensions = bool(int(os.environ.get('EMLEARN_BUILD_EXTENSIONS', '0')))
+
 class get_pybind_include(object):
     """Helper class to determine the pybind11 include path
     The purpose of this class is to postpone importing pybind11
@@ -133,13 +135,13 @@ setup(
             'eml-mel-filterbank = emlearn.tools.mel_filterbank:main',
         ],
     },
-    ext_modules=ext_modules,
+    ext_modules=ext_modules if enable_extensions else [],
     include_package_data=True,
     package_data = {
         '': ['*.h', '*.ino'],
     },
     install_requires=read_requirements(),
     setup_requires=['pybind11>=2.2'], # pybind11 needed at pip install time
-    cmdclass={'build_ext': BuildExt},
+    cmdclass={'build_ext': BuildExt} if enable_extensions else {},
     zip_safe=False,
 )

--- a/test/test_audio.py
+++ b/test/test_audio.py
@@ -13,7 +13,13 @@ import librosa.display
 import pandas
 
 import emlearn
-import eml_audio
+
+# TODO: replace with C programs compiled at runtime
+skip_eml_audio = None
+try:
+    import eml_audio
+except ImportError as e:
+    skip_eml_audio = "eml_audio extension not built"
 
 FFT_SIZES = [
     64,
@@ -23,6 +29,7 @@ FFT_SIZES = [
     1024,
 ]
 @pytest.mark.parametrize('n_fft', FFT_SIZES)
+@pytest.mark.skipif(bool(skip_eml_audio), reason=skip_eml_audio)
 def test_rfft_simple(n_fft):
     signal = numpy.arange(0, n_fft)
 
@@ -32,6 +39,7 @@ def test_rfft_simple(n_fft):
 
     numpy.testing.assert_allclose(out, ref, rtol=1e-4)
 
+@pytest.mark.skipif(bool(skip_eml_audio), reason=skip_eml_audio)
 def test_rfft_not_power2_length():
     with pytest.raises(Exception) as e:
         eml_audio.rfft(numpy.array([0,1,3,4,5]))
@@ -141,6 +149,7 @@ def melfilter_ref(pow_frames, sr, n_mels, n_fft):
     filtered = numpy.dot(pow_frames, fbank.T)
     return filtered
 
+@pytest.mark.skipif(bool(skip_eml_audio), reason=skip_eml_audio)
 def test_melfilter_basic():
     n_mels = 16
     n_fft = 512
@@ -171,6 +180,7 @@ def test_melfilter_basic():
     numpy.testing.assert_allclose(out, ref, rtol=1e-3)
 
 
+@pytest.mark.skipif(bool(skip_eml_audio), reason=skip_eml_audio)
 def test_melfilter_librosa():
     filename = librosa.util.example("vibeace", hq=True)
     y, sr = librosa.load(filename, offset=1.0, duration=0.3)
@@ -263,6 +273,7 @@ def test_sparse_filterbank_ref():
     assert coeffs[-1] == pytest.approx(2.8125530662e-05)
 
 
+@pytest.mark.skipif(bool(skip_eml_audio), reason=skip_eml_audio)
 def test_sparse_filterbank_apply():
     n_fft = 1024
     n_mels = 30

--- a/test/test_audio.py
+++ b/test/test_audio.py
@@ -29,7 +29,7 @@ FFT_SIZES = [
     1024,
 ]
 @pytest.mark.parametrize('n_fft', FFT_SIZES)
-@pytest.mark.skipif(bool(skip_eml_audio), reason=skip_eml_audio)
+@pytest.mark.skipif(bool(skip_eml_audio), reason=str(skip_eml_audio))
 def test_rfft_simple(n_fft):
     signal = numpy.arange(0, n_fft)
 
@@ -39,7 +39,7 @@ def test_rfft_simple(n_fft):
 
     numpy.testing.assert_allclose(out, ref, rtol=1e-4)
 
-@pytest.mark.skipif(bool(skip_eml_audio), reason=skip_eml_audio)
+@pytest.mark.skipif(bool(skip_eml_audio), reason=str(skip_eml_audio))
 def test_rfft_not_power2_length():
     with pytest.raises(Exception) as e:
         eml_audio.rfft(numpy.array([0,1,3,4,5]))
@@ -149,7 +149,7 @@ def melfilter_ref(pow_frames, sr, n_mels, n_fft):
     filtered = numpy.dot(pow_frames, fbank.T)
     return filtered
 
-@pytest.mark.skipif(bool(skip_eml_audio), reason=skip_eml_audio)
+@pytest.mark.skipif(bool(skip_eml_audio), reason=str(skip_eml_audio))
 def test_melfilter_basic():
     n_mels = 16
     n_fft = 512
@@ -180,7 +180,7 @@ def test_melfilter_basic():
     numpy.testing.assert_allclose(out, ref, rtol=1e-3)
 
 
-@pytest.mark.skipif(bool(skip_eml_audio), reason=skip_eml_audio)
+@pytest.mark.skipif(bool(skip_eml_audio), reason=str(skip_eml_audio))
 def test_melfilter_librosa():
     filename = librosa.util.example("vibeace", hq=True)
     y, sr = librosa.load(filename, offset=1.0, duration=0.3)
@@ -273,7 +273,7 @@ def test_sparse_filterbank_ref():
     assert coeffs[-1] == pytest.approx(2.8125530662e-05)
 
 
-@pytest.mark.skipif(bool(skip_eml_audio), reason=skip_eml_audio)
+@pytest.mark.skipif(bool(skip_eml_audio), reason=str(skip_eml_audio))
 def test_sparse_filterbank_apply():
     n_fft = 1024
     n_mels = 30

--- a/test/test_filters.py
+++ b/test/test_filters.py
@@ -5,7 +5,12 @@ import pandas
 
 import pytest
 
-import eml_signal
+# TODO: replace with C programs compiled at runtime
+skip_eml_signal = None
+try:
+    import eml_signal
+except ImportError as e:
+    skip_eml_signal = "eml_signal extension not built"
 
 
 def plot_freq_response(noise, a, b, fs=44100):
@@ -43,6 +48,7 @@ FILTERS = {
 }
 
 
+@pytest.mark.skipif(bool(skip_eml_signal), reason=skip_eml_signal)
 @pytest.mark.parametrize('filtername', FILTERS.keys())
 def test_iir_filter(filtername):
     sos = FILTERS[filtername]

--- a/test/test_filters.py
+++ b/test/test_filters.py
@@ -48,7 +48,7 @@ FILTERS = {
 }
 
 
-@pytest.mark.skipif(bool(skip_eml_signal), reason=skip_eml_signal)
+@pytest.mark.skipif(bool(skip_eml_signal), reason=str(skip_eml_signal))
 @pytest.mark.parametrize('filtername', FILTERS.keys())
 def test_iir_filter(filtername):
     sos = FILTERS[filtername]


### PR DESCRIPTION
So that we do not require a C/C++ compiler for basic usage.
Longer term the binary modules for signal/IIR and audio/melspectrogram should be replaced with C programs that can be used as subprocesses.