### PR TITLE
trees: Fixup support for different dtype with inline inference

### DIFF
--- a/emlearn/bayes.py
+++ b/emlearn/bayes.py
@@ -106,6 +106,9 @@ class Wrapper(object):
                 model[class_n,feature_n] = (mean, std, std_log2)
         self.model = model
 
+        if method is None:
+            method = 'loadable'
+
         if method == 'loadable':
             name = 'mybayes'
             func = 'eml_bayes_predict(&{}_model, values, length)'.format(name)
@@ -114,7 +117,7 @@ class Wrapper(object):
         elif method == 'inline':
             raise NotImplementedError('NaiveBayes does not support inline C code generation')
         else:
-            raise ValueError("Unsupported classifier method '{}'".format(classifier))
+            raise ValueError(f"Unsupported inference method '{method}'")
 
 
     def predict(self, X):

--- a/emlearn/convert.py
+++ b/emlearn/convert.py
@@ -12,6 +12,7 @@ from . import distance
 from . import mixture
 from . import neighbors
 
+from typing import Optional
 
 class Model():
     """Inference model powered by emlearn
@@ -46,7 +47,7 @@ class Model():
 
 def convert(estimator, 
         kind : str = None,
-        method: str = 'loadable',
+        method: Optional[str] = None,
         dtype: str = None,
         return_type: str = 'classifier',
         **kwargs,

--- a/emlearn/mixture.py
+++ b/emlearn/mixture.py
@@ -302,6 +302,9 @@ class Wrapper:
         self.dtype = dtype
         self.verbose = verbose
 
+        if classifier is None:
+            classifier = 'loadable'
+    
         n_components, n_features = estimator.means_.shape
         covariance_type = estimator.covariance_type
         precisions_chol = estimator.precisions_cholesky_

--- a/emlearn/neighbors.py
+++ b/emlearn/neighbors.py
@@ -37,6 +37,9 @@ class Wrapper:
 
         check_params_supported(estimator)
 
+        if inference is None:
+            inference = 'loadable'
+
         self.fit_data_X = estimator._fit_X
         self.fit_data_Y = estimator._y
         self.n_neighbors = estimator.n_neighbors

--- a/emlearn/net.py
+++ b/emlearn/net.py
@@ -36,6 +36,9 @@ class Wrapper:
             use_fixedpoint=False,
         ):
 
+        if classifier is None:
+            classifier = 'loadable'
+
         self.activations = activations
         self.weights = weights
         self.biases = biases

--- a/emlearn/trees.py
+++ b/emlearn/trees.py
@@ -332,7 +332,8 @@ def generate_c_inlined(forest, name, n_features, n_classes=0, leaf_bits=0, dtype
     nodes, roots, leaves = forest
 
     cgen.assert_valid_identifier(name)
-    #assert leaf_bits == 0, 'class proportions not supported for inline yet'
+    if classifier and leaf_bits != 0:
+        raise ValueError('Class proportions not supported for inline yet. Must use leaf_bits=0')
 
     tree_names = [ name + '_tree_{}'.format(i) for i,_ in enumerate(roots) ]
 

--- a/emlearn/trees.py
+++ b/emlearn/trees.py
@@ -524,7 +524,10 @@ class Wrapper:
             self.n_classes = estimators[0].n_classes_
         self.method = classifier
         if self.method not in ('loadable', 'inline'):
-            raise ValueError("Unsupported classifier method '{}'".format(classifier))
+            raise ValueError("Unsupported inference method '{}'".format(classifier))
+
+        if self.method == 'loadable' and self.dtype != 'int16_t':
+            raise ValueError("Inference method='loadable' only supports dtype='int16_t'. Use method='inline' for others")
 
         # TODO: support more features for inline. Like 255
         max_features = 127 if self.method == 'loadable' else 10000
@@ -658,7 +661,11 @@ class Wrapper:
         probabilities = self.classifier_.predict_proba(X)
         return probabilities
 
-    def save(self, name=None, file=None, format='c', inference=['inline', 'loadable']):
+    def save(self, name=None, file=None, format='c', inference=None):
+
+        if inference is None:
+            inference = ['inline', 'loadable']
+
         if name is None:
             if file is None:
                 raise ValueError('Either name or file must be provided')

--- a/emlearn/trees.py
+++ b/emlearn/trees.py
@@ -6,6 +6,7 @@ Tree-based models
 
 import os.path
 import os
+import warnings
 
 import numpy
 
@@ -742,6 +743,13 @@ class Wrapper:
 
         if inference is None:
             inference = [self.method]
+        else:
+            if len(inference) != 1:
+                raise ValueError('Only support specifying on inference type on save')
+            warnings.warn("The 'inference' argument is deprecated. It will be removed in a future version. Use method= in constructor instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
 
         if name is None:
             if file is None:

--- a/emlearn/trees.py
+++ b/emlearn/trees.py
@@ -527,7 +527,10 @@ def generate_c_loadable(forest, name, n_features,
 
 
 class Wrapper:
-    def __init__(self, estimator, classifier, dtype='int16_t', leaf_bits=None):
+    def __init__(self, estimator, method, dtype='int16_t', leaf_bits=None):
+
+        if method is None:
+            method = 'inline'
 
         self.dtype = dtype
         if self.dtype is None:
@@ -564,9 +567,9 @@ class Wrapper:
         self.n_classes = 0
         if self.is_classifier:
             self.n_classes = estimators[0].n_classes_
-        self.method = classifier
+        self.method = method
         if self.method not in ('loadable', 'inline'):
-            raise ValueError("Unsupported inference method '{}'".format(classifier))
+            raise ValueError("Unsupported inference method '{}'".format(self.method))
 
         if self.method == 'loadable' and self.dtype != 'int16_t':
             raise ValueError("Inference method='loadable' only supports dtype='int16_t'. Use method='inline' for others")

--- a/emlearn/trees.py
+++ b/emlearn/trees.py
@@ -431,7 +431,7 @@ def generate_c_inlined(forest, name, n_features, n_classes=0, leaf_bits=0, dtype
     })
 
 
-    forest_proba_func = """EmlError {function_name}(const {ctype} *features, int32_t features_length, float *out, int out_length) {{
+    forest_proba_func = """int {function_name}(const {ctype} *features, int32_t features_length, float *out, int out_length) {{
 
         int32_t _class = -1;
 
@@ -445,7 +445,7 @@ def generate_c_inlined(forest, name, n_features, n_classes=0, leaf_bits=0, dtype
         for (int i=0; i<out_length; i++) {{
             out[i] = out[i] / {n_trees};
         }}
-        return EmlOk;
+        return 0;
     }}
     """.format(**{
       'function_name': name+"_predict_proba",
@@ -470,7 +470,7 @@ def generate_c_inlined(forest, name, n_features, n_classes=0, leaf_bits=0, dtype
     head = """
     // !!! This file is generated using emlearn !!!
 
-    #include <eml_trees.h>
+    #include <stdint.h>
     """
 
     return '\n\n'.join([head] + tree_funcs + forest_funcs)
@@ -641,7 +641,7 @@ class Wrapper:
                 return out;
             }}""",
             f"""
-            EmlError
+            int
             predict_proba_inline(const float *values, int length, float *outputs, int n_outputs) {{
                 // Convert to whatever is needed for inline
                 {feature_dtype} features[{n_features}];
@@ -649,7 +649,7 @@ class Wrapper:
                     features[i] = ({feature_dtype})values[i];
                 }}
 
-                const EmlError err = \
+                const int err = \
                     {name}_predict_proba(features, length, outputs, n_outputs);
 
                 return err;

--- a/emlearn/trees.py
+++ b/emlearn/trees.py
@@ -578,9 +578,7 @@ class Wrapper:
 
         return_type = 'int32_t' if self.is_classifier else 'float'
 
-        code = '\n'.join([
-            model_init,
-
+        classifier_functions = [
             # Floating point wrappers for loadable, that is compatible with CompilerClassifier
             f"""
             int32_t
@@ -646,6 +644,9 @@ class Wrapper:
                 return err;
             }}
             """,
+        ]
+
+        regression_functions = [
             # Floating point wrappers for regress loadable, that is compatible with CompilerClassifier
             f"""
             float
@@ -672,7 +673,15 @@ class Wrapper:
                 return out;
             }}
             """,
-        ])
+        ]
+
+        sections = [model_init]
+        if self.is_classifier:
+            sections += classifier_functions
+        else:
+            sections += regression_functions
+
+        code = '\n'.join(sections)
 
         with open('treegen.h', 'w') as f:
             f.write(code)

--- a/examples/classifiers.py
+++ b/examples/classifiers.py
@@ -112,6 +112,8 @@ def check_correctness(out_dir, name, model_filename, test_data, test_predictions
     except subprocess.CalledProcessError as e:
         errors = e.returncode
 
+    return errors
+
 # %%
 # Plotting tools
 # ------------------------
@@ -155,7 +157,7 @@ def build_run_classifier(ax, model, name):
         os.makedirs(out_dir)
 
     model_filename = os.path.join(out_dir, f'{name}_model.h')
-    cmodel = emlearn.convert(model, method='loadable')
+    cmodel = emlearn.convert(model, method=None, dtype='float')
     code = cmodel.save(file=model_filename, name='model')
 
     test_pred = cmodel.predict(test[feature_columns])

--- a/examples/trees-feature-quantization-arm+Cortex-M0.csv
+++ b/examples/trees-feature-quantization-arm+Cortex-M0.csv
@@ -1,7 +1,7 @@
 platform,cpu,dtype,flash,ram
-arm,Cortex-M0,loadable,5336,264
-arm,Cortex-M0,float,4372,240
-arm,Cortex-M0,int32_t,2380,240
-arm,Cortex-M0,int16_t,2752,120
-arm,Cortex-M0,int8_t,2600,60
-arm,Cortex-M0,uint8_t,2244,60
+arm,Cortex-M0,loadable,4876,144
+arm,Cortex-M0,float,4288,240
+arm,Cortex-M0,int32_t,2228,240
+arm,Cortex-M0,int16_t,2596,120
+arm,Cortex-M0,int8_t,2428,60
+arm,Cortex-M0,uint8_t,2164,60

--- a/examples/trees-feature-quantization-arm+Cortex-M4F.csv
+++ b/examples/trees-feature-quantization-arm+Cortex-M4F.csv
@@ -1,7 +1,7 @@
 platform,cpu,dtype,flash,ram
-arm,Cortex-M4F,loadable,3544,264
-arm,Cortex-M4F,float,4444,240
-arm,Cortex-M4F,int32_t,1880,240
-arm,Cortex-M4F,int16_t,2080,120
-arm,Cortex-M4F,int8_t,2080,60
-arm,Cortex-M4F,uint8_t,1892,60
+arm,Cortex-M4F,loadable,2444,144
+arm,Cortex-M4F,float,4312,240
+arm,Cortex-M4F,int32_t,1888,240
+arm,Cortex-M4F,int16_t,2068,120
+arm,Cortex-M4F,int8_t,2068,60
+arm,Cortex-M4F,uint8_t,1888,60

--- a/examples/trees-feature-quantization-avr+atmega2560.csv
+++ b/examples/trees-feature-quantization-avr+atmega2560.csv
@@ -1,7 +1,7 @@
 platform,cpu,dtype,flash,ram
-avr,atmega2560,loadable,4934,2472
-avr,atmega2560,float,6944,240
-avr,atmega2560,int32_t,6000,240
-avr,atmega2560,int16_t,4496,120
-avr,atmega2560,int8_t,2480,60
-avr,atmega2560,uint8_t,2466,60
+avr,atmega2560,loadable,4496,1764
+avr,atmega2560,float,6684,240
+avr,atmega2560,int32_t,5838,240
+avr,atmega2560,int16_t,4122,120
+avr,atmega2560,int8_t,2490,60
+avr,atmega2560,uint8_t,2484,60

--- a/examples/trees_feature_quantization.py
+++ b/examples/trees_feature_quantization.py
@@ -87,7 +87,7 @@ def check_program_size(dtype, model, platform, mcu):
     if model_enabled:
         # Quantize with the specified dtype
         c_model = emlearn.convert(model, dtype=dtype, method=method)
-        model_code = c_model.save(name=model_name, inference=[method])
+        model_code = c_model.save(name=model_name, include_proba=False)
 
         if method == 'loadable':
             # Only works for size estimation
@@ -100,6 +100,9 @@ def check_program_size(dtype, model, platform, mcu):
 
     test_program = \
     f"""
+    // Disable unused features
+    #define EML_TREES_REGRESSION_ENABLE 0
+
     #include <stdint.h>
 
     #if {model_enabled}

--- a/examples/trees_feature_quantization.py
+++ b/examples/trees_feature_quantization.py
@@ -73,26 +73,27 @@ from emlearn.evaluate.size import get_program_size, check_build_tools
 
 def check_program_size(dtype, model, platform, mcu):
 
-    model_name = 'sizecheck'
     features_length = model.estimators_[0].n_features_in_
     model_enabled = 0 if dtype == 'no-model' else 1
     if dtype == 'loadable':
-        dtype = 'float'
+        dtype = 'int16_t'
         method = 'loadable'
     else:
         method = 'inline'
 
+    model_name = f'sizecheck_{method}_{dtype}'
+
+    print(model_name)
     if model_enabled:
         # Quantize with the specified dtype
-        c_model = emlearn.convert(model, dtype=dtype, method='loadable')
+        c_model = emlearn.convert(model, dtype=dtype, method=method)
         model_code = c_model.save(name=model_name, inference=[method])
 
         if method == 'loadable':
-            # XXX: the cast to float is wrong. Will crash horribly during execution
             # Only works for size estimation
             model_code += f"""
             int {model_name}_predict(const {dtype} *f, int l) {{
-                return eml_trees_predict(&{model_name}, (float *)f, l);
+                return eml_trees_predict(&{model_name}, ({dtype} *)f, l);
             }}"""
     else:
         model_code = ""

--- a/test/test_arduino.py
+++ b/test/test_arduino.py
@@ -77,8 +77,5 @@ def test_arduino_helloworld():
     # build sketch
     out = arduino_build(out_dir, library_dir=os.path.join(library_dir, 'emlearn'))
     assert 'Sketch uses' in out
-    assert 'Used library' in out
-    assert 'emlearn' in out
-    assert library_dir in out
 
 

--- a/test/test_trees.py
+++ b/test/test_trees.py
@@ -279,4 +279,17 @@ def test_trees_too_many_features(method, deep_trees_model):
     with pytest.raises(ValueError, match='features'):
         cmodel = emlearn.convert(estimator, method=method)
 
+LOADABLE_UNSUPPORTED_FEATURE_DTYPES=['float', 'int8_t', 'uint8_t', 'int32_t']
+@pytest.mark.parametrize("dtype", LOADABLE_UNSUPPORTED_FEATURE_DTYPES)
+def test_trees_loadable_unsupported_dtype(dtype):
+    """Should raise error during convert()"""
+
+    X, Y = datasets.make_classification(n_classes=10, n_features=10,
+        n_informative=8, n_samples=100, random_state=1)
+    estimator = RandomForestClassifier(n_estimators=5, random_state=1)
+    estimator.fit(X, Y)
+
+    with pytest.raises(ValueError, match='loadable'):
+        cmodel = emlearn.convert(estimator, method='loadable', dtype=dtype)
+
 


### PR DESCRIPTION
Only the _inline_ inference method for trees supports configurable data type (the _loadable_ is limited to int16_t). However the tests for this functionality were not good enough, so this functionality had bitrotted a bit.

Changes

- Loadable and dtype != int16_t is an error
- There should only be code for one inference method in save() output
- predict_proba should be supported for inline. Can be disabled by using save(include_proba=False)
- Inline should work with any dtype, including float
- Inline is now the default inference method for trees, where-as loadable stays default for other methods
- Provide mymodel_predict() and mymodel_predict_proba() wrappers functions also for loadable inference method