### PR TITLE
eml_csv: Basic support for reading/writing CSV files

### DIFF
--- a/emlearn/eml_csv.h
+++ b/emlearn/eml_csv.h
@@ -1,0 +1,187 @@
+
+// Basic support for Comma Separated Values (CSV)
+// As per RFC4180, https://www.ietf.org/rfc/rfc4180.txt
+// Not intended to parse every wierd "csv" like thing out there
+// Just the well-formed thing, that can be produced from typical PyData etc tools
+
+#include <eml_common.h>
+#include <eml_io.h>
+
+#include <stdint.h>
+#include <string.h>
+
+
+#define EML_CSV_DELIMITER ","
+#define EML_CSV_EOL "\n"
+
+typedef struct _EmlCsvReader {
+
+    size_t n_columns;
+
+    // IO
+    EmlIoReadFunction read;
+    EmlIoSeekFunction seek;
+    void *stream;
+} EmlCsvReader;
+
+
+typedef struct _EmlCsvWriter {
+
+    size_t n_columns;
+
+    // IO
+    EmlIoWriteFunction write;
+    EmlIoSeekFunction seek;
+    void *stream;
+} EmlCsvWriter;
+
+
+// Writer
+EmlError
+eml_csv_writer_write_header(EmlCsvWriter *self, const char **columns, size_t n_columns)
+{
+
+    // Keep number of expected values per row
+    self->n_columns = n_columns;
+    const int data_length = n_columns;
+
+    const char *delimiter = EML_CSV_DELIMITER;
+    const char *endline = EML_CSV_EOL;
+
+    char buf[10] = {0,};
+    for (int i=0; i<data_length; i++) {
+        const char *name = columns[i];
+        const int length = strlen(name);
+        self->write(self->stream, name, length);
+        const bool is_last = (i == data_length-1);
+        if (!is_last) {
+            self->write(self->stream, delimiter, 1);
+        }
+    }
+
+    self->write(self->stream, endline, 1);
+
+    return EmlOk;
+}
+
+EmlError
+eml_csv_writer_write_data(EmlCsvWriter *self, const float *data, size_t data_length)
+{
+    EML_PRECONDITION(self->n_columns == data_length, EmlSizeMismatch);
+
+    const char *endline = EML_CSV_EOL;
+
+    char buf[10] = {0,};
+    for (int i=0; i<data_length; i++) {
+        int written = snprintf(buf, 10, "%f", data[i]);
+        const bool is_last = (i == data_length-1);
+        if (!is_last) {
+            buf[written] = (EML_CSV_DELIMITER)[0];
+            written += 1;
+        }
+        self->write(self->stream, buf, written);
+    }
+    self->write(self->stream, endline, 1);
+
+    return EmlOk;
+}
+
+// Reader
+
+EmlError
+eml_csv_reader_read_internal(EmlCsvReader *self,
+        char *buffer, size_t buffer_length,
+        char **columns, size_t columns_length,
+        int *out_columns, int *out_offset
+        )
+{
+
+    // Copy the (potential header) into our buffer
+    // We will return pointers into this buffer
+    const size_t read_length = self->read(self->stream, buffer, buffer_length);
+
+    // Find start of data / end-of-header
+    int data_start = -1;
+
+    // Find each column
+    int column_idx = 0;
+    int column_start_offset = 0;
+    int offset = -1;
+    for (offset=0; offset<read_length; offset++) {
+
+        const char c = buffer[offset];
+        if (c == (EML_CSV_DELIMITER)[0]) {
+            // Keep a pointer to start of this column
+            columns[column_idx] = buffer+column_start_offset;
+            column_start_offset = offset+1;
+            column_idx += 1;
+
+            // NULL terminate previous string
+            buffer[offset] = '\0';
+            if (column_idx >= columns_length) {
+                printf("parse-too-many-columns read=%d max=%d \n", column_idx, columns_length);
+                return EmlUnknownError;
+            }
+        } else if (c == (EML_CSV_EOL)[0]) {
+            buffer[offset] = '\0';
+            break;
+        }
+    }
+
+    *out_columns = column_idx;
+    *out_offset = offset;
+
+    return EmlOk;
+}
+
+
+EmlError
+eml_csv_reader_read_header(EmlCsvReader *self,
+        char *buffer, size_t buffer_length,
+        char **columns, size_t columns_length)
+{
+    int columns_read = 0;
+    int characters_read = 0;
+
+    EmlError read_err = eml_csv_reader_read_internal(self, \
+        buffer, buffer_length, columns, columns_length, &columns_read, &characters_read);
+
+    // Rembember number of columns
+    self->n_columns = columns_read;
+
+    // Seek to start of data
+    const int seek_status = self->seek(self->stream, characters_read+1);
+    if (seek_status != 0) {
+        return EmlUnknownError;
+    }
+    return EmlOk;
+}
+
+EmlError
+eml_csv_reader_read_data(EmlCsvReader *self,
+        char *buffer, size_t buffer_length,
+        char **columns, size_t columns_length)
+{
+    EML_PRECONDITION(columns_length >= self->n_columns, EmlSizeMismatch);
+
+    int columns_read = 0;
+    int characters_read = 0;
+
+    EmlError read_err = eml_csv_reader_read_internal(self, \
+        buffer, buffer_length, columns, columns_length, &columns_read, &characters_read);
+    EML_CHECK_ERROR(read_err);
+
+    if (columns_read != self->n_columns) {
+        printf("uncorrect-columns read=%d \n", columns_read);
+        return EmlUnknownError;
+    }
+
+    // Seek to start of next line
+    const int seek_status = self->seek(self->stream, characters_read+1);
+    if (seek_status != 0) {
+        return EmlUnknownError;
+    }
+
+    return EmlOk;
+}
+

--- a/emlearn/eml_csv.h
+++ b/emlearn/eml_csv.h
@@ -116,10 +116,6 @@ eml_csv_reader_read_internal(EmlCsvReader *self,
     // We will return pointers into this buffer
     const size_t read_length = self->read(self->stream, buffer, buffer_length);
 
-#if 1
-    printf("read-internal %.*s \n", read_length, buffer);
-#endif
-
     // Find start of data / end-of-header
     int data_start = -1;
 
@@ -205,7 +201,9 @@ eml_csv_reader_read_data(EmlCsvReader *self,
     }
 
     if (columns_read != self->n_columns) {
+#if 0
         printf("uncorrect-columns read=%d \n", columns_read);
+#endif
         return -EmlUnknownError;
     }
 

--- a/emlearn/eml_fileio.h
+++ b/emlearn/eml_fileio.h
@@ -1,0 +1,49 @@
+ 
+/*
+eml_fileio.h
+
+Utilities for I/O streams using FILE objects from C standard library.
+Useful together with EmlCsvReader / EmlCsvWriter and related.
+*/
+
+#ifndef EML_FILEIO_H
+#define EML_FILEIO_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdio.h>
+
+/**
+* \brief Implements EmlIoWriteFunction for FILE stream
+*/
+int eml_fileio_write(void *context, const uint8_t *buffer, size_t size)
+{
+    FILE* fptr = context;
+    return fwrite(buffer, 1, size, fptr);
+}
+
+/**
+* \brief Implements EmlIoReadFunction for FILE stream
+*/
+int eml_fileio_read(void *context, uint8_t *buffer, size_t size)
+{
+    FILE* fptr = context;
+    return fread(buffer, 1, size, fptr);
+}
+
+/**
+* \brief Implements EmlIoSeekFunction for FILE stream
+*/
+int eml_fileio_seek(void *context, size_t position)
+{
+    FILE* fptr = context;
+    return fseek(fptr, position, SEEK_SET);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // EML_FILEIO_H

--- a/emlearn/eml_io.h
+++ b/emlearn/eml_io.h
@@ -1,0 +1,18 @@
+
+#ifndef EML_IO_H
+#define EML_IO_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// I/O functions for streams
+typedef int (*EmlIoReadFunction)(void *context, uint8_t *buffer, size_t size);
+typedef int (*EmlIoSeekFunction)(void *context, size_t position);
+typedef int (*EmlIoWriteFunction)(void *context, const uint8_t *buffer, size_t size);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // EML_IO_H

--- a/test/test_all.c
+++ b/test/test_all.c
@@ -11,6 +11,7 @@
 #include "test_quantizer.c"
 #include "test_trees.c"
 #include "test_net.c"
+#include "test_csv_file.c"
 
 #include <unity.c>
 
@@ -22,13 +23,14 @@ typedef struct _TestModule {
     TestModuleFunction func;
 } TestModule;
 
-#define TEST_MODULES 5
+#define TEST_MODULES 6
 TestModule test_modules[TEST_MODULES] = {
     { "array", test_eml_array },
     { "neighbors", test_eml_neighbors },
     { "quantizer", test_eml_quantizer },
     { "net", test_eml_net },
     { "trees", test_eml_trees },
+    { "csv_file", test_eml_csv_file },
 };
 
 void

--- a/test/test_c.py
+++ b/test/test_c.py
@@ -21,6 +21,7 @@ C_TEST_MODULES = [
     'neighbors',
     'quantizer',
     'net',
+    'csv_file',
 ]
 
 def parse_test_summary(stdout):

--- a/test/test_csv_file.c
+++ b/test/test_csv_file.c
@@ -1,0 +1,166 @@
+
+#include <eml_csv.h>
+#include <eml_fileio.h>
+
+#include <unity.h>
+
+
+void
+test_trees_xor_predict()
+{
+    // Basic check that we can discriminate between data from two different classes
+    EmlError err = EmlOk;
+    int16_t out_label = -1;
+
+    float buffer1[TEST_BUFFER_LENGTH];
+    float buffer2[TEST_BUFFER_LENGTH];
+
+    // Setup XOR model, single decision tree
+    int32_t roots[1] = { 0 };
+    uint8_t leaves[2] = { 0, 1 };
+    EmlTreesNode nodes[] = {
+        // feature, value, left, right
+        { 0, 0, 1, 2 },
+        { 1, 0, -1, -2 },
+        { 1, 0, -2, -1 },
+    };
+    EmlTrees _model;
+    EmlTrees *model = &_model;
+
+    model->n_nodes = 3;
+    model->nodes = nodes;
+    model->n_trees = 1;
+    model->tree_roots = roots;
+    model->n_leaves = 2;
+    model->leaves = leaves;
+    model->leaf_bits = 0; // majority voting
+    model->n_features = 2;
+    model->n_classes = 2;
+
+    // Test data
+    int16_t test_data[TEST_XOR_ROWS][TEST_XOR_FEATURES+1] = {
+        // in1, in2 -> out 
+        { -1, -1,  0 },
+        {  1,  1,  0 },
+        { -1,  1,  1 },
+        {  1, -1,  1 },
+    };
+
+    float out[2];
+
+    for (int i=0; i<TEST_XOR_ROWS; i++) {
+        const int16_t *data = test_data[i];
+        const int16_t expect_class = data[2];   
+        const float expect_proba0 = (expect_class == 0) ? 1.0f : 0.0f;
+        const float expect_proba1 = (expect_class == 0) ? 0.0f : 1.0f;
+
+        printf("test-xor case=%d in=[%d %d] expect=%d\n", i, data[0], data[1], expect_class);
+
+        const EmlError err = eml_trees_predict_proba(model, data, TEST_XOR_FEATURES, out, 2);
+        TEST_ASSERT_EQUAL(EmlOk, err);
+        TEST_ASSERT_FLOAT_WITHIN(0.01f, expect_proba0, out[0]);
+        TEST_ASSERT_FLOAT_WITHIN(0.01f, expect_proba1, out[1]);
+
+        const int out = eml_trees_predict(model, data, TEST_XOR_FEATURES);
+        TEST_ASSERT_EQUAL(out, expect_class);
+    }
+}
+
+
+
+#define N_DATA_COLUMNS 7
+const char *columns[] = {
+    "time",
+    "acc_x",
+    "acc_y",
+    "acc_z",
+    "gyro_x",
+    "gyro_y",
+    "gyro_z",
+};
+
+#define READ_BUFFER_SIZE 1024
+char read_buffer[READ_BUFFER_SIZE];
+
+#define READ_COLUMNS_MAX 10
+char *read_columns[READ_COLUMNS_MAX];
+
+void test_csv_file_write_readback()
+{
+    // Writes a CSV file, then read it back
+    const char *filename = "test/out/write_readback.csv";
+
+    // Write some simple file
+    FILE *write_file = fopen(filename, "w");
+    
+    EmlCsvWriter _writer = {
+        .n_columns = N_DATA_COLUMNS,
+        .write = eml_fileio_write,
+        .stream = write_file,
+    };
+    EmlCsvWriter *writer = &_writer;
+
+    EmlError header_err = eml_csv_writer_write_header(writer, columns, N_DATA_COLUMNS);
+    TEST_ASSERT_EQUAL(EmlOk, header_err);
+
+    const float values[N_DATA_COLUMNS] = \
+        { 0.0f, 1.1f, 2.2f, 3.3f, 4.4f, 5.5f, 6.6f };
+
+    EmlError write_err = EmlUnknownError;
+    const int write_rows = 2;
+    for (int i=0; i<write_rows; i++) {
+        write_err = eml_csv_writer_write_data(writer, values, N_DATA_COLUMNS);
+        TEST_ASSERT_EQUAL(EmlOk, write_err);
+    }
+
+    write_err = eml_csv_writer_write_data(writer, values, N_DATA_COLUMNS);
+    TEST_ASSERT_EQUAL(EmlOk, write_err);
+
+    printf("write-done header=%d write=%d \n", header_err, write_err);
+    fclose(write_file);
+    
+
+    // Read back
+    FILE *read_file = fopen(filename, "r");
+    EmlCsvReader _reader = {
+        .seek = eml_fileio_seek,
+        .read = eml_fileio_read,
+        .stream = read_file,
+    };
+    EmlCsvReader *reader = &_reader;
+
+    EmlError read_header_err = eml_csv_reader_read_header(reader,\
+        read_buffer, READ_BUFFER_SIZE, read_columns, READ_COLUMNS_MAX);
+    TEST_ASSERT_EQUAL(EmlOk, read_header_err);
+
+    printf("header-status err=%d columms=%d\n", read_header_err, reader->n_columns);
+
+    const int expect_columns = N_DATA_COLUMNS;
+    TEST_ASSERT_EQUAL(expect_columns, reader->n_columns);
+
+    // TODO: check that columns are correct
+    printf("columns: \n");
+    for (int i=0; i<reader->n_columns; i++) {
+        printf("%s\n", read_columns[i]);
+    }
+
+    // TODO: read all rows, check got everything
+    EmlError data_err = eml_csv_reader_read_data(reader,\
+        read_buffer, READ_BUFFER_SIZE, read_columns, READ_COLUMNS_MAX);
+    TEST_ASSERT_EQUAL(EmlOk, data_err);
+
+    printf("data-status err=%d\n", data_err);
+    for (int i=0; i<reader->n_columns; i++) {
+        const float v = strtod(read_columns[i], NULL);
+        printf("%s %f\n", read_columns[i], v);
+    }
+
+}
+
+
+void
+test_eml_csv_file()
+{
+    // Add tests here
+    RUN_TEST(test_csv_file_write_readback);
+}

--- a/test/test_csv_file.c
+++ b/test/test_csv_file.c
@@ -79,13 +79,12 @@ void test_csv_file_write_readback()
     const int expect_columns = N_DATA_COLUMNS;
     TEST_ASSERT_EQUAL(expect_columns, reader->n_columns);
 
-    // TODO: read all rows, check got everything
-    int read_values;
-
+    int read_values = -1;
     for (int row=0; row<100; row++) {
         read_values = eml_csv_reader_read_data(reader,\
             read_buffer, READ_BUFFER_SIZE, read_columns, READ_COLUMNS_MAX);
         if (read_values == 0) {
+            TEST_ASSERT_EQUAL(write_rows, row);
             break;
         }
         TEST_ASSERT_EQUAL(expect_columns, read_values);
@@ -93,7 +92,7 @@ void test_csv_file_write_readback()
         for (int v=0; v<reader->n_columns; v++) {
             const float got = strtod(read_columns[v], NULL);
             const float expect = values[(row*N_DATA_COLUMNS)+v];
-            printf("read-value-compare expect=%f got=%f\n", expect, got);
+            //printf("read-value-compare expect=%f got=%f\n", expect, got);
             TEST_ASSERT_FLOAT_WITHIN(0.01f, expect, got);
         }
     }

--- a/test/test_csv_file.c
+++ b/test/test_csv_file.c
@@ -5,69 +5,6 @@
 #include <unity.h>
 
 
-void
-test_trees_xor_predict()
-{
-    // Basic check that we can discriminate between data from two different classes
-    EmlError err = EmlOk;
-    int16_t out_label = -1;
-
-    float buffer1[TEST_BUFFER_LENGTH];
-    float buffer2[TEST_BUFFER_LENGTH];
-
-    // Setup XOR model, single decision tree
-    int32_t roots[1] = { 0 };
-    uint8_t leaves[2] = { 0, 1 };
-    EmlTreesNode nodes[] = {
-        // feature, value, left, right
-        { 0, 0, 1, 2 },
-        { 1, 0, -1, -2 },
-        { 1, 0, -2, -1 },
-    };
-    EmlTrees _model;
-    EmlTrees *model = &_model;
-
-    model->n_nodes = 3;
-    model->nodes = nodes;
-    model->n_trees = 1;
-    model->tree_roots = roots;
-    model->n_leaves = 2;
-    model->leaves = leaves;
-    model->leaf_bits = 0; // majority voting
-    model->n_features = 2;
-    model->n_classes = 2;
-
-    // Test data
-    int16_t test_data[TEST_XOR_ROWS][TEST_XOR_FEATURES+1] = {
-        // in1, in2 -> out 
-        { -1, -1,  0 },
-        {  1,  1,  0 },
-        { -1,  1,  1 },
-        {  1, -1,  1 },
-    };
-
-    float out[2];
-
-    for (int i=0; i<TEST_XOR_ROWS; i++) {
-        const int16_t *data = test_data[i];
-        const int16_t expect_class = data[2];   
-        const float expect_proba0 = (expect_class == 0) ? 1.0f : 0.0f;
-        const float expect_proba1 = (expect_class == 0) ? 0.0f : 1.0f;
-
-        printf("test-xor case=%d in=[%d %d] expect=%d\n", i, data[0], data[1], expect_class);
-
-        const EmlError err = eml_trees_predict_proba(model, data, TEST_XOR_FEATURES, out, 2);
-        TEST_ASSERT_EQUAL(EmlOk, err);
-        TEST_ASSERT_FLOAT_WITHIN(0.01f, expect_proba0, out[0]);
-        TEST_ASSERT_FLOAT_WITHIN(0.01f, expect_proba1, out[1]);
-
-        const int out = eml_trees_predict(model, data, TEST_XOR_FEATURES);
-        TEST_ASSERT_EQUAL(out, expect_class);
-    }
-}
-
-
-
 #define N_DATA_COLUMNS 7
 const char *columns[] = {
     "time",
@@ -79,7 +16,7 @@ const char *columns[] = {
     "gyro_z",
 };
 
-#define READ_BUFFER_SIZE 1024
+#define READ_BUFFER_SIZE 2*1024
 char read_buffer[READ_BUFFER_SIZE];
 
 #define READ_COLUMNS_MAX 10
@@ -103,22 +40,21 @@ void test_csv_file_write_readback()
     EmlError header_err = eml_csv_writer_write_header(writer, columns, N_DATA_COLUMNS);
     TEST_ASSERT_EQUAL(EmlOk, header_err);
 
-    const float values[N_DATA_COLUMNS] = \
-        { 0.0f, 1.1f, 2.2f, 3.3f, 4.4f, 5.5f, 6.6f };
+    const float values[2*N_DATA_COLUMNS] = {
+        0.0f, 1.1f, 2.2f, -3356.910f, 4.4f, -5.5f, 666.666f,
+        1.0f, 99.1f, 2.2f, -3.14f, 4.4f, -5.5f, -6.6f,
+    };
 
     EmlError write_err = EmlUnknownError;
     const int write_rows = 2;
     for (int i=0; i<write_rows; i++) {
-        write_err = eml_csv_writer_write_data(writer, values, N_DATA_COLUMNS);
+        const float *row = values + (i * N_DATA_COLUMNS);
+        write_err = eml_csv_writer_write_data(writer, row, N_DATA_COLUMNS);
         TEST_ASSERT_EQUAL(EmlOk, write_err);
     }
-
-    write_err = eml_csv_writer_write_data(writer, values, N_DATA_COLUMNS);
-    TEST_ASSERT_EQUAL(EmlOk, write_err);
-
     printf("write-done header=%d write=%d \n", header_err, write_err);
     fclose(write_file);
-    
+   
 
     // Read back
     FILE *read_file = fopen(filename, "r");
@@ -133,26 +69,33 @@ void test_csv_file_write_readback()
         read_buffer, READ_BUFFER_SIZE, read_columns, READ_COLUMNS_MAX);
     TEST_ASSERT_EQUAL(EmlOk, read_header_err);
 
-    printf("header-status err=%d columms=%d\n", read_header_err, reader->n_columns);
+#if 0
+    printf("read-columns: \n");
+    for (int i=0; i<reader->n_columns; i++) {
+        printf("%s\n", read_columns[i]);
+    }
+#endif
 
     const int expect_columns = N_DATA_COLUMNS;
     TEST_ASSERT_EQUAL(expect_columns, reader->n_columns);
 
-    // TODO: check that columns are correct
-    printf("columns: \n");
-    for (int i=0; i<reader->n_columns; i++) {
-        printf("%s\n", read_columns[i]);
-    }
-
     // TODO: read all rows, check got everything
-    EmlError data_err = eml_csv_reader_read_data(reader,\
-        read_buffer, READ_BUFFER_SIZE, read_columns, READ_COLUMNS_MAX);
-    TEST_ASSERT_EQUAL(EmlOk, data_err);
+    int read_values;
 
-    printf("data-status err=%d\n", data_err);
-    for (int i=0; i<reader->n_columns; i++) {
-        const float v = strtod(read_columns[i], NULL);
-        printf("%s %f\n", read_columns[i], v);
+    for (int row=0; row<100; row++) {
+        read_values = eml_csv_reader_read_data(reader,\
+            read_buffer, READ_BUFFER_SIZE, read_columns, READ_COLUMNS_MAX);
+        if (read_values == 0) {
+            break;
+        }
+        TEST_ASSERT_EQUAL(expect_columns, read_values);
+
+        for (int v=0; v<reader->n_columns; v++) {
+            const float got = strtod(read_columns[v], NULL);
+            const float expect = values[(row*N_DATA_COLUMNS)+v];
+            printf("read-value-compare expect=%f got=%f\n", expect, got);
+            TEST_ASSERT_FLOAT_WITHIN(0.01f, expect, got);
+        }
     }
 
 }


### PR DESCRIPTION
The IO stream definitions will also be used for for .npy file support, ref #109 

Later: Remove the CSV code in eml_test.h