### PR TITLE
docs: document Zephyr motion example

### DIFF
--- a/docs/getting_started_zephyr.rst
+++ b/docs/getting_started_zephyr.rst
@@ -4,9 +4,9 @@
 
 .. _getting_started_zephyr:
 
-=========================
+==============================
 Getting started on Zephyr RTOS
-=========================
+==============================
 
 .. currentmodule:: emlearn
 
@@ -35,7 +35,7 @@ The QEMU board specifically requires the ``arm-zephyr-eabi`` compiler toolchain,
 and the ``cmsis`` and ``hal_nordic`` Zephyr modules.
 
 Add emlearn to your Zephyr project
-========================
+==================================
 
 emlearn provides the neccesary metadata to be used a Zephyr module (since Feburary 2024).
 To include the module, add an entry to the ``projects`` section of your ``west.yml`` configuration.
@@ -58,7 +58,7 @@ This should now pull the emlearn git repository into your workspace.
 
 
 Enable emlearn in your Zephyr project
-========================
+=====================================
 
 Once you have the emlearn Zephyr module, you must enable it in your application.
 You can add this manually to your configuration file.
@@ -102,7 +102,7 @@ Here is some example code for calling the XOR model on some inputs.
 
 
 Build and run in simulator
-========================
+==========================
 
 We are assuming that your code is called `helloworld_xor`.
 
@@ -126,4 +126,22 @@ This should result in output similar to this:
     xor(1,1) = 0
 
 
+Sensor data example
+========================
+
+For a more practical sensor-data workflow, the repository also includes a
+Zephyr motion-recognition example:
+`platform_examples/zephyr/motion_recognition <https://github.com/emlearn/emlearn/tree/master/platform_examples/zephyr/motion_recognition>`_.
+
+This example targets the XIAO BLE Sense nRF52840 board and its LSM6DSL
+accelerometer/gyroscope. It demonstrates how a Zephyr application can:
+
+* read accelerometer and gyroscope samples through Zephyr's sensor API
+* store captured samples as CSV data
+* run the portable motion preprocessing code used by the host-side example
+* generate preprocessing/model headers from Python tools during a west build
+
+The motion-recognition example is marked as a work in progress, but it is a
+useful starting point when adapting emlearn to real sensor data instead of the
+XOR toy example.
 

--- a/examples/motion_recognition/README.md
+++ b/examples/motion_recognition/README.md
@@ -7,7 +7,7 @@ Can be used for tasks such as Human Activity Recognition, etc.
 ## Usage
 
 For example usage, see
-[platform_examples/zephyr/motion_recognition](platform_examples/zephyr/motion_recognition).
+[platform_examples/zephyr/motion_recognition](../../platform_examples/zephyr/motion_recognition).
 
 
 ## Running tests

--- a/platform_examples/zephyr/motion_recognition/README.rst
+++ b/platform_examples/zephyr/motion_recognition/README.rst
@@ -1,8 +1,13 @@
 Motion classification
-********
+*********************
+
+This sample shows how to use emlearn with Zephyr and real motion sensor data.
+It reads accelerometer and gyroscope samples from the LSM6DSL sensor on the
+XIAO BLE Sense nRF52840 board, writes captured samples to CSV, and runs the
+same feature extraction code used by the host-side motion-recognition example.
 
 Status
-************************
+******
 
 **Work in progress**.
 
@@ -13,6 +18,9 @@ Implemented
 * Preprocessing code for motion, with IIR gravity estimation and FFT analysis of motion 
 * Generating the model/preprocessing code as part of west build, using CMake targets
 * Tool for running preprocessing/model on CSV files, for training and validation on PC
+
+This sample currently demonstrates data capture and feature extraction on the
+device. The live classifier call is still a TODO in ``src/main.c``.
 
 TODO complete example
 
@@ -57,9 +65,14 @@ Need to have Python3 and install some dependencies
     source venv/bin/activate
     pip install emlearn
 
+The west build also runs Python helper scripts from
+``examples/motion_recognition/tools`` to generate headers for the model and the
+gravity low-pass filter. Those generated headers are written into the Zephyr
+build directory.
+
 
 Building on XIAO BLE Sense NRF52840 board
-==========================
+==========================================
 
 .. code-block:: console
 
@@ -71,5 +84,9 @@ Sample Output
 
 .. code-block:: console
 
-    TODO
+    features run_err=0 copy_err=0 write_err=0 | l=300 dt=0.962 time=12.345
+    features run_err=0 copy_err=0 write_err=0 | l=300 dt=0.963 time=13.308
 
+The ``features`` log line means that the application received a sensor window,
+wrote it to CSV, ran motion preprocessing, and copied the extracted feature
+vector. The exact timing values depend on the board and sampling configuration.


### PR DESCRIPTION
## Summary
- Link the Zephyr getting-started guide to the existing motion-recognition sensor-data example
- Clarify the current Zephyr motion example scope: LSM6DSL capture, CSV writing, and preprocessing/feature extraction
- Fix the host motion-recognition README link and clean up RST heading underlines touched by the docs update

## Testing
- git diff --check
- RST heading underline check
- Not run: python -m pytest -q test\test_zephyr.py because pytest is not installed in the current Python environment

Refs #108